### PR TITLE
Fix resource leak and improve testability in ImageService

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `RestoreFromBackupAsync` method used `ZipFile.ExtractToDirectory` without validating that the extracted file paths were contained within the destination directory. This could allow an attacker to write files outside the intended directory via a crafted zip archive containing `../` traversal sequences.
 **Learning:** Even if modern frameworks (like .NET 6+) offer some protection, explicit path validation ("Defense in Depth") is crucial for critical file operations. Always ensure the resolved full path starts with the intended target directory *and* includes a trailing separator to prevent partial path matching bypasses.
 **Prevention:** Replace convenient one-liners like `ExtractToDirectory` with manual iteration and validation loops when handling untrusted archives. Verify `!destinationPath.StartsWith(targetDir + Path.DirectorySeparatorChar)` before writing.
+
+## 2024-05-23 - Unrestricted Image Download (DoS Risk)
+**Vulnerability:** `ImageService.DownloadImageFromUrlAsync` used `HttpClient.GetAsync` without `HttpCompletionOption.ResponseHeadersRead`, causing the entire response body to be buffered into memory before any checks could be performed. This exposed the application to Denial of Service (DoS) via "zip bomb" or massive file attacks.
+**Learning:** `HttpClient.GetAsync` defaults to buffering the entire response. For file downloads, always use `HttpCompletionOption.ResponseHeadersRead` to inspect headers (Content-Length, Content-Type) *before* committing to download the body.
+**Prevention:** Always validate `Content-Length` and `Content-Type` headers before reading the response stream for external resources. Enforce reasonable size limits (e.g., 10MB for images).

--- a/BookLoggerApp.Tests/Security/ImageSecurityTests.cs
+++ b/BookLoggerApp.Tests/Security/ImageSecurityTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using BookLoggerApp.Core.Services.Abstractions;
+using BookLoggerApp.Infrastructure.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+
+namespace BookLoggerApp.Tests.Security;
+
+public class ImageSecurityTests
+{
+    private readonly Mock<IFileSystem> _mockFileSystem;
+    private readonly Mock<ILogger<ImageService>> _mockLogger;
+    private ImageService _imageService;
+    private readonly string _testImagesDir;
+
+    public ImageSecurityTests()
+    {
+        _mockFileSystem = new Mock<IFileSystem>();
+        _mockLogger = new Mock<ILogger<ImageService>>();
+
+        _testImagesDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "covers");
+
+        _mockFileSystem.Setup(fs => fs.CombinePath(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns((string p1, string p2) => Path.Combine(p1, p2));
+
+        _mockFileSystem.Setup(fs => fs.CreateDirectory(It.IsAny<string>()));
+    }
+
+    [Fact]
+    public async Task DownloadImageFromUrlAsync_ShouldRejectLargeFiles()
+    {
+        // Arrange
+        var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new ByteArrayContent(new byte[0])
+                {
+                    Headers = { ContentLength = 11 * 1024 * 1024 } // 11 MB
+                }
+            });
+
+        var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+
+        // Inject HttpClient directly using the internal constructor
+        _imageService = new ImageService(_mockFileSystem.Object, _mockLogger.Object, httpClient);
+
+        // Act
+        var result = await _imageService.DownloadImageFromUrlAsync("http://example.com/large.jpg");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task DownloadImageFromUrlAsync_ShouldRejectInvalidContentType()
+    {
+        // Arrange
+        var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("<html><body>Not an image</body></html>", System.Text.Encoding.UTF8, "text/html")
+            });
+
+        var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+
+        _imageService = new ImageService(_mockFileSystem.Object, _mockLogger.Object, httpClient);
+
+        // Act
+        var result = await _imageService.DownloadImageFromUrlAsync("http://example.com/notimage.html");
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task DownloadImageFromUrlAsync_ShouldAcceptValidImage()
+    {
+        // Arrange
+        var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+        mockHttpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new ByteArrayContent(new byte[] { 0xFF, 0xD8, 0xFF }) // Pseudo JPG header
+                {
+                    Headers = { ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("image/jpeg") }
+                }
+            });
+
+        var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+
+        _imageService = new ImageService(_mockFileSystem.Object, _mockLogger.Object, httpClient);
+
+        // Act
+        var result = await _imageService.DownloadImageFromUrlAsync("http://example.com/image.jpg");
+
+        // Assert
+        Assert.NotNull(result);
+    }
+}


### PR DESCRIPTION
- Added internal constructor to `ImageService` for HttpClient injection.
- Ensure `response.Dispose()` is called when download is rejected.
- Updated `ImageSecurityTests` to use injected HttpClient instead of reflection.
- Safely handle missing `Content-Length` (warn but proceed, with comment on future improvements).