### PR TITLE
fix: show changelog after update when version has no dedicated entry

### DIFF
--- a/BookLoggerApp.Core/Helpers/ChangelogParser.cs
+++ b/BookLoggerApp.Core/Helpers/ChangelogParser.cs
@@ -5,6 +5,8 @@ namespace BookLoggerApp.Core.Helpers;
 
 public static class ChangelogParser
 {
+    public const string UnreleasedVersion = "unreleased";
+
     private static readonly Regex ReleaseHeaderRegex = new(
         @"^## \[(?<version>[^\]]+)\](?: - (?<date>.+))?$",
         RegexOptions.Compiled);
@@ -35,7 +37,7 @@ public static class ChangelogParser
 
                 if (string.Equals(displayVersion, "Unveröffentlicht", StringComparison.OrdinalIgnoreCase))
                 {
-                    currentRelease = null;
+                    currentRelease = new ChangelogReleaseBuilder(UnreleasedVersion, displayVersion, releaseDate);
                     continue;
                 }
 

--- a/BookLoggerApp.Core/Services/Abstractions/IChangelogService.cs
+++ b/BookLoggerApp.Core/Services/Abstractions/IChangelogService.cs
@@ -6,4 +6,5 @@ public interface IChangelogService
 {
     Task<IReadOnlyList<ChangelogRelease>> GetReleaseHistoryAsync(CancellationToken ct = default);
     Task<ChangelogRelease?> GetReleaseAsync(string version, CancellationToken ct = default);
+    Task<ChangelogRelease?> GetUnreleasedChangesAsync(CancellationToken ct = default);
 }

--- a/BookLoggerApp.Core/ViewModels/AppStartupViewModel.cs
+++ b/BookLoggerApp.Core/ViewModels/AppStartupViewModel.cs
@@ -314,6 +314,20 @@ public partial class AppStartupViewModel : ViewModelBase, IDisposable
         CurrentRelease = ReleaseHistory.FirstOrDefault(release =>
             string.Equals(release.Version, ChangelogParser.NormalizeVersion(CurrentVersion), StringComparison.OrdinalIgnoreCase));
 
+        if (CurrentRelease == null)
+        {
+            var unreleased = await _changelogService.GetUnreleasedChangesAsync(ct);
+            if (unreleased?.Sections.Count > 0)
+            {
+                CurrentRelease = new ChangelogRelease
+                {
+                    Version = ChangelogParser.NormalizeVersion(CurrentVersion),
+                    DisplayVersion = CurrentVersion,
+                    Sections = unreleased.Sections
+                };
+            }
+        }
+
         if (CurrentRelease != null)
         {
             IsChangelogVisible = true;

--- a/BookLoggerApp.Tests/Unit/Helpers/ChangelogParserTests.cs
+++ b/BookLoggerApp.Tests/Unit/Helpers/ChangelogParserTests.cs
@@ -7,7 +7,7 @@ namespace BookLoggerApp.Tests.Unit.Helpers;
 public class ChangelogParserTests
 {
     [Fact]
-    public void Parse_ShouldIgnoreUnreleased_AndKeepReleasedVersions()
+    public void Parse_ShouldIncludeUnreleased_WithSpecialVersion()
     {
         // Arrange
         const string markdown = """
@@ -30,10 +30,38 @@ public class ChangelogParserTests
         var releases = ChangelogParser.Parse(markdown);
 
         // Assert
-        releases.Should().HaveCount(1);
-        releases[0].Version.Should().Be("0.8.0");
+        releases.Should().HaveCount(2);
+        releases[0].Version.Should().Be(ChangelogParser.UnreleasedVersion);
+        releases[0].DisplayVersion.Should().Be("Unveröffentlicht");
         releases[0].Sections.Should().ContainSingle();
-        releases[0].Sections[0].Entries.Should().ContainSingle("Neue Funktion");
+        releases[0].Sections[0].Entries.Should().ContainSingle("Noch nicht veröffentlicht");
+        releases[1].Version.Should().Be("0.8.0");
+        releases[1].Sections.Should().ContainSingle();
+        releases[1].Sections[0].Entries.Should().ContainSingle("Neue Funktion");
+    }
+
+    [Fact]
+    public void Parse_ShouldBuildEmptyUnreleasedEntry_WhenNoSectionsExist()
+    {
+        // Arrange
+        const string markdown = """
+            ## [Unveröffentlicht]
+
+            ## [0.8.0] - 2026-04-07
+
+            ### Hinzugefügt
+
+            - Neue Funktion
+            """;
+
+        // Act
+        var releases = ChangelogParser.Parse(markdown);
+
+        // Assert
+        releases.Should().HaveCount(2);
+        releases[0].Version.Should().Be(ChangelogParser.UnreleasedVersion);
+        releases[0].Sections.Should().BeEmpty();
+        releases[1].Version.Should().Be("0.8.0");
     }
 
     [Fact]

--- a/BookLoggerApp.Tests/Unit/ViewModels/AppStartupViewModelTests.cs
+++ b/BookLoggerApp.Tests/Unit/ViewModels/AppStartupViewModelTests.cs
@@ -1,3 +1,4 @@
+using BookLoggerApp.Core.Helpers;
 using BookLoggerApp.Core.Models;
 using BookLoggerApp.Core.Services.Abstractions;
 using BookLoggerApp.Core.Infrastructure;
@@ -43,6 +44,8 @@ public class AppStartupViewModelTests
                 }
             }
         });
+        _changelogService.GetUnreleasedChangesAsync(Arg.Any<CancellationToken>())
+            .Returns((ChangelogRelease?)null);
         _appUpdateService.GetStateAsync(Arg.Any<CancellationToken>()).Returns(AppUpdateState.Unsupported);
         _onboardingService.GetSnapshotAsync(Arg.Any<CancellationToken>()).Returns(CreateSnapshot());
         _onboardingService.RefreshSnapshotAsync(Arg.Any<CancellationToken>()).Returns(CreateSnapshot());
@@ -301,6 +304,68 @@ public class AppStartupViewModelTests
         handled.Should().BeTrue();
         _viewModel.OnboardingCurrentStep.Should().Be(1);
         await _onboardingService.Received(1).RetreatIntroAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ShouldFallbackToUnreleased_WhenNoExactVersionMatch()
+    {
+        // Arrange
+        _appVersionService.CurrentVersion.Returns("0.9.2");
+        _appVersionService.IsFirstLaunchForCurrentVersion.Returns(true);
+        _changelogService.GetReleaseHistoryAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new ChangelogRelease
+            {
+                Version = "0.9.0",
+                DisplayVersion = "0.9.0",
+                Sections = new[] { new ChangelogSection { Title = "Hinzugefügt", Entries = new[] { "Altes Feature" } } }
+            }
+        });
+        _changelogService.GetUnreleasedChangesAsync(Arg.Any<CancellationToken>()).Returns(new ChangelogRelease
+        {
+            Version = ChangelogParser.UnreleasedVersion,
+            DisplayVersion = "Unveröffentlicht",
+            Sections = new[] { new ChangelogSection { Title = "Hinzugefügt", Entries = new[] { "Neues Feature" } } }
+        });
+
+        // Act
+        await _viewModel.InitializeAsync();
+
+        // Assert
+        _viewModel.IsChangelogVisible.Should().BeTrue();
+        _viewModel.CurrentRelease.Should().NotBeNull();
+        _viewModel.CurrentRelease!.Version.Should().Be("0.9.2");
+        _viewModel.CurrentRelease.DisplayVersion.Should().Be("0.9.2");
+        _viewModel.CurrentRelease.Sections[0].Entries.Should().Contain("Neues Feature");
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ShouldNotShowChangelog_WhenNoMatchAndUnreleasedIsEmpty()
+    {
+        // Arrange
+        _appVersionService.CurrentVersion.Returns("0.9.2");
+        _appVersionService.IsFirstLaunchForCurrentVersion.Returns(true);
+        _changelogService.GetReleaseHistoryAsync(Arg.Any<CancellationToken>()).Returns(new[]
+        {
+            new ChangelogRelease
+            {
+                Version = "0.9.0",
+                DisplayVersion = "0.9.0",
+                Sections = new[] { new ChangelogSection { Title = "Hinzugefügt", Entries = new[] { "Altes Feature" } } }
+            }
+        });
+        _changelogService.GetUnreleasedChangesAsync(Arg.Any<CancellationToken>()).Returns(new ChangelogRelease
+        {
+            Version = ChangelogParser.UnreleasedVersion,
+            DisplayVersion = "Unveröffentlicht",
+            Sections = Array.Empty<ChangelogSection>()
+        });
+
+        // Act
+        await _viewModel.InitializeAsync();
+
+        // Assert
+        _viewModel.IsChangelogVisible.Should().BeFalse();
     }
 
     private static OnboardingSnapshot CreateSnapshot(

--- a/BookLoggerApp/Services/ChangelogService.cs
+++ b/BookLoggerApp/Services/ChangelogService.cs
@@ -7,34 +7,14 @@ namespace BookLoggerApp.Services;
 public sealed class ChangelogService : IChangelogService
 {
     private readonly SemaphoreSlim _gate = new(1, 1);
-    private IReadOnlyList<ChangelogRelease>? _cachedReleases;
+    private IReadOnlyList<ChangelogRelease>? _allReleases;
 
     public async Task<IReadOnlyList<ChangelogRelease>> GetReleaseHistoryAsync(CancellationToken ct = default)
     {
-        if (_cachedReleases != null)
-        {
-            return _cachedReleases;
-        }
-
-        await _gate.WaitAsync(ct);
-
-        try
-        {
-            if (_cachedReleases != null)
-            {
-                return _cachedReleases;
-            }
-
-            await using var stream = await FileSystem.OpenAppPackageFileAsync("CHANGELOG.md");
-            using var reader = new StreamReader(stream);
-            var markdown = await reader.ReadToEndAsync(ct);
-            _cachedReleases = ChangelogParser.Parse(markdown);
-            return _cachedReleases;
-        }
-        finally
-        {
-            _gate.Release();
-        }
+        await EnsureParsedAsync(ct);
+        return _allReleases!
+            .Where(r => !string.Equals(r.Version, ChangelogParser.UnreleasedVersion, StringComparison.OrdinalIgnoreCase))
+            .ToList();
     }
 
     public async Task<ChangelogRelease?> GetReleaseAsync(string version, CancellationToken ct = default)
@@ -44,5 +24,39 @@ public sealed class ChangelogService : IChangelogService
 
         return releases.FirstOrDefault(release =>
             string.Equals(release.Version, normalizedVersion, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public async Task<ChangelogRelease?> GetUnreleasedChangesAsync(CancellationToken ct = default)
+    {
+        await EnsureParsedAsync(ct);
+        return _allReleases!.FirstOrDefault(r =>
+            string.Equals(r.Version, ChangelogParser.UnreleasedVersion, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private async Task EnsureParsedAsync(CancellationToken ct)
+    {
+        if (_allReleases != null)
+        {
+            return;
+        }
+
+        await _gate.WaitAsync(ct);
+
+        try
+        {
+            if (_allReleases != null)
+            {
+                return;
+            }
+
+            await using var stream = await FileSystem.OpenAppPackageFileAsync("CHANGELOG.md");
+            using var reader = new StreamReader(stream);
+            var markdown = await reader.ReadToEndAsync(ct);
+            _allReleases = ChangelogParser.Parse(markdown);
+        }
+        finally
+        {
+            _gate.Release();
+        }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ Versionsschema:
   - Analysen-Tab: Jahresvergleich, Genre-Radar (Spinnennetz-Diagramm), Abschlussquote (Donut-Chart), Buchlängen-Vorliebe, Meistgelesene Autoren
 - Genre-spezifische Bewertungskategorien: 5 neue Kategorien (Spannung, Humor, Informationsgehalt, Emotionale Tiefe, Atmosphäre) ergänzen die bestehenden 6 Kategorien. Beim Bewerten eines Buches werden nur die zum Genre passenden Kategorien angezeigt — weitere Kategorien lassen sich per Dropdown aufklappen.
 
+### Behoben
+
+- Changelog wird nach einem Update wieder zuverlässig in der App angezeigt, auch wenn die aktuelle Version noch keinen eigenen Changelog-Eintrag hat
+
 ### Geändert
 
 - "Getting Started"-Seite auf sehr kleinen mobilen Displays kompakter gestaltet: engeres Hero-Layout, kleinere Kartenabstände und reduzierter vertikaler Leerraum ohne Funktionsänderung


### PR DESCRIPTION
The changelog modal was not displayed after updates because the app
version (0.9.2) had no matching entry in CHANGELOG.md — changes were
under [Unveröffentlicht] which the parser skipped entirely.

Fix: ChangelogParser now includes unreleased content with a special
version marker. When no exact version match exists, LoadChangelogAsync
falls back to showing the unreleased section with the current app
version as display name.

https://claude.ai/code/session_01U5LaHjRCqyg3Hxrbubyh8b