### PR TITLE
fix: show per-level XP instead of cumulative XP in level milestones

### DIFF
--- a/BookLoggerApp.Core/ViewModels/StatsViewModel.cs
+++ b/BookLoggerApp.Core/ViewModels/StatsViewModel.cs
@@ -431,22 +431,12 @@ public partial class StatsViewModel : ViewModelBase
         // Show up to +5 future levels
         int endLevel = CurrentLevel + 5;
 
-        // Calculate cumulative XP
-        int cumulativeXp = 0;
-        for (int level = 1; level < startLevel; level++)
-        {
-            cumulativeXp += GetXpForLevel(level);
-        }
-
         for (int level = startLevel; level <= endLevel; level++)
         {
-            int xpForThisLevel = GetXpForLevel(level);
-            cumulativeXp += xpForThisLevel;
-
             milestones.Add(new LevelMilestone
             {
                 Level = level,
-                XpRequired = cumulativeXp,
+                XpRequired = GetXpForLevel(level),
                 CoinsReward = level * 50,
                 IsCompleted = level < CurrentLevel,
                 IsCurrent = level == CurrentLevel

--- a/BookLoggerApp.Tests/Unit/ViewModels/StatsViewModelTests.cs
+++ b/BookLoggerApp.Tests/Unit/ViewModels/StatsViewModelTests.cs
@@ -175,4 +175,27 @@ public class StatsViewModelTests
         // Assert
         _viewModel.PlantBoosts.Should().BeEmpty();
     }
+
+    [Fact]
+    public async Task LoadAsync_Should_Generate_PerLevel_XpValues_Not_Cumulative()
+    {
+        // Arrange
+        var settings = new AppSettings { UserLevel = 3, TotalXp = 600, Coins = 0 };
+        _settingsProvider.GetSettingsAsync().Returns(settings);
+        _plantService.GetAllAsync().Returns(new List<UserPlant>());
+        _plantService.CalculateTotalXpBoostAsync().Returns(0m);
+
+        // Act
+        await _viewModel.LoadCommand.ExecuteAsync(null);
+
+        // Assert — XpRequired should be 100 × Level² (per-level), not cumulative
+        _viewModel.LevelMilestones.Should().NotBeEmpty();
+
+        foreach (var milestone in _viewModel.LevelMilestones)
+        {
+            int expectedXp = 100 * milestone.Level * milestone.Level;
+            milestone.XpRequired.Should().Be(expectedXp,
+                because: $"Level {milestone.Level} requires 100 × {milestone.Level}² = {expectedXp} XP");
+        }
+    }
 }


### PR DESCRIPTION
GenerateLevelMilestones() was accumulating XP across all levels, causing
milestone cards to display values in the millions for higher levels.
Now shows the correct per-level requirement (100 × Level²).

https://claude.ai/code/session_011q2jVmJ6y94u4RQqFmnovg