### PR TITLE
Fix level badge text wrapping in plant boost cards

### DIFF
--- a/BookLoggerApp/wwwroot/css/stats.css
+++ b/BookLoggerApp/wwwroot/css/stats.css
@@ -349,6 +349,8 @@
     padding: 0.2rem 0.4rem;
     border-radius: 6px;
     font-weight: 600;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .plant-boost-value {


### PR DESCRIPTION
Add white-space: nowrap and flex-shrink: 0 to .plant-level so
"Lv. 1" always renders on a single line, even on narrow screens.

https://claude.ai/code/session_01K8CNtyYzjUU3EFyD2f9tGy