### PR TITLE
Add AGENTS.md with Cursor Cloud specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+See `CLAUDE.md` for comprehensive project documentation including architecture, patterns, templates, and localization.
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- **.NET 10 SDK** is installed at `/usr/share/dotnet`. The update script handles installation if missing.
+- `ApiKeys.cs` is gitignored. The update script copies the template automatically. No real API key is needed — anonymous Google Books access works with rate limits.
+
+### Building
+
+This is a .NET MAUI Blazor Hybrid **Android** app. In the Cloud Agent VM (headless Linux), only the non-MAUI projects can be built and tested:
+
+```bash
+# Build the three non-MAUI projects (matches CI)
+dotnet build BookLoggerApp.Core/BookLoggerApp.Core.csproj
+dotnet build BookLoggerApp.Infrastructure/BookLoggerApp.Infrastructure.csproj
+dotnet build BookLoggerApp.Tests/BookLoggerApp.Tests.csproj
+```
+
+The MAUI project (`BookLoggerApp/BookLoggerApp.csproj`) targets `net10.0-android` and requires the Android SDK workload — it **cannot** be built or run in the Cloud Agent VM. This matches the CI workflow which also only builds Core + Tests.
+
+### Testing
+
+```bash
+dotnet test BookLoggerApp.Tests/BookLoggerApp.Tests.csproj
+```
+
+All tests use EF Core InMemory provider and require no external services or network access. The test suite currently has 1,237 tests.
+
+### Lint
+
+No standalone linter is configured. Build warnings serve as the lint mechanism — `TreatWarningsAsErrors` is `false` in all projects. Existing warnings in the codebase (MVVMTK0034, CS0414, CA2000) are known and accepted.
+
+### Key gotchas
+
+- The `.editorconfig` enforces LF line endings. Ensure any new files use LF, not CRLF.
+- Tests pin `CultureInfo` to `InvariantCulture` via a `[ModuleInitializer]` in `TestHelpers/TestStringLocalizer.cs` to avoid locale-dependent failures.
+- `DatabaseInitializationHelper.MarkAsInitialized()` must be called in ViewModel test constructors — see patterns in `CLAUDE.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section for future Cloud Agent sessions.

### What's included

- Environment setup notes (.NET 10 SDK path, `ApiKeys.cs` template handling)
- Build instructions scoped to the three non-MAUI projects (Core, Infrastructure, Tests) — the MAUI Android project cannot build in headless Linux VMs, matching CI behavior
- Test running instructions (1,237 xUnit tests, EF Core InMemory, no external dependencies)
- Key gotchas (LF line endings, `InvariantCulture` pinning in tests, `DatabaseInitializationHelper.MarkAsInitialized()` requirement)

References `CLAUDE.md` for full project documentation rather than duplicating it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69044ee0-1689-4d5d-8133-c83cc68ecbc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69044ee0-1689-4d5d-8133-c83cc68ecbc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

