### PR TITLE
Fix localized wishlist priorities

### DIFF
--- a/BookLoggerApp.Core/Resources/WishlistPriorityLocalization.cs
+++ b/BookLoggerApp.Core/Resources/WishlistPriorityLocalization.cs
@@ -1,0 +1,13 @@
+using BookLoggerApp.Core.Enums;
+using Microsoft.Extensions.Localization;
+
+namespace BookLoggerApp.Core.Resources;
+
+public static class WishlistPriorityLocalization
+{
+    public static string LocalizedLabel(this WishlistPriority priority, IStringLocalizer<AppResources> l)
+    {
+        LocalizedString value = l[$"Priority_{priority}"];
+        return value.ResourceNotFound ? priority.ToString() : value.Value;
+    }
+}

--- a/BookLoggerApp.Tests/Unit/Resources/WishlistPriorityLocalizationTests.cs
+++ b/BookLoggerApp.Tests/Unit/Resources/WishlistPriorityLocalizationTests.cs
@@ -3,6 +3,7 @@ using BookLoggerApp.Core.Enums;
 using BookLoggerApp.Core.Resources;
 using BookLoggerApp.Tests.TestHelpers;
 using FluentAssertions;
+using Xunit;
 
 namespace BookLoggerApp.Tests.Unit.Resources;
 

--- a/BookLoggerApp.Tests/Unit/Resources/WishlistPriorityLocalizationTests.cs
+++ b/BookLoggerApp.Tests/Unit/Resources/WishlistPriorityLocalizationTests.cs
@@ -1,0 +1,35 @@
+using System.Globalization;
+using BookLoggerApp.Core.Enums;
+using BookLoggerApp.Core.Resources;
+using BookLoggerApp.Tests.TestHelpers;
+using FluentAssertions;
+
+namespace BookLoggerApp.Tests.Unit.Resources;
+
+public class WishlistPriorityLocalizationTests
+{
+    private readonly TestStringLocalizer<AppResources> _localizer = new();
+
+    [Fact]
+    public void LocalizedLabel_UsesGermanTranslation_WhenCurrentCultureIsGerman()
+    {
+        CultureInfo originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo originalUiCulture = CultureInfo.CurrentUICulture;
+
+        try
+        {
+            CultureInfo german = CultureInfo.GetCultureInfo("de");
+            CultureInfo.CurrentCulture = german;
+            CultureInfo.CurrentUICulture = german;
+
+            WishlistPriority.High.LocalizedLabel(_localizer).Should().Be("Hoch");
+            WishlistPriority.Medium.LocalizedLabel(_localizer).Should().Be("Mittel");
+            WishlistPriority.Low.LocalizedLabel(_localizer).Should().Be("Niedrig");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+            CultureInfo.CurrentUICulture = originalUiCulture;
+        }
+    }
+}

--- a/BookLoggerApp/Components/Pages/BookDetail.razor
+++ b/BookLoggerApp/Components/Pages/BookDetail.razor
@@ -193,7 +193,7 @@
                     <div class="wishlist-meta-item">
                         <span class="book-meta-label">@L["BookDetail_Priority"]</span>
                         <span class="wishlist-priority priority-@ViewModel.Book.WishlistInfo.Priority.ToString().ToLower()">
-                            @GetPriorityLabel(ViewModel.Book.WishlistInfo.Priority)
+                            @ViewModel.Book.WishlistInfo.Priority.LocalizedLabel(L)
                         </span>
                     </div>
                     @if (!string.IsNullOrEmpty(ViewModel.Book.WishlistInfo.RecommendedBy))
@@ -580,14 +580,6 @@
         await ViewModel.UpdateRatingAsync(category, rating);
         await InvokeAsync(StateHasChanged);
     }
-    private string GetPriorityLabel(BookLoggerApp.Core.Enums.WishlistPriority priority) => priority switch
-    {
-        BookLoggerApp.Core.Enums.WishlistPriority.High => L["Priority_High"],
-        BookLoggerApp.Core.Enums.WishlistPriority.Medium => L["Priority_Medium"],
-        BookLoggerApp.Core.Enums.WishlistPriority.Low => L["Priority_Low"],
-        _ => L["Priority_Medium"]
-    };
-
     private async Task HandleMoveToLibrary()
     {
         if (ViewModel.Book == null) return;

--- a/BookLoggerApp/Components/Pages/Bookshelf.razor
+++ b/BookLoggerApp/Components/Pages/Bookshelf.razor
@@ -301,7 +301,7 @@
                             @if (book.WishlistInfo != null)
                             {
                                 <span class="wishlist-priority priority-@book.WishlistInfo.Priority.ToString().ToLower()">
-                                    @book.WishlistInfo.Priority
+                                    @book.WishlistInfo.Priority.LocalizedLabel(L)
                                 </span>
                                 @if (!string.IsNullOrEmpty(book.WishlistInfo.RecommendedBy))
                                 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Versionsschema:
 ### Geändert
 - Startgeschwindigkeit verbessert: die veraltete Legacy-Datenbank-Migration (Pfad `Personal` → `LocalApplicationData`) wurde vom Startpfad entfernt. Sie lief bei jedem Kaltstart synchron und durchsuchte das Dateisystem, obwohl alle Bestandsdaten längst am aktuellen Speicherort liegen. Bestehende Daten sind nicht betroffen.
 
+### Behoben
+- Wunschlisten-Prioritäten werden in der Bücherregal-/Wunschlistenansicht jetzt korrekt in der aktiven App-Sprache angezeigt statt als englische Enum-Werte.
+
 ## [0.11.2]
 
 ### Hinzugefügt


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- localize wishlist priority labels through a shared `WishlistPriority` resource helper
- use the helper in wishlist cards and book detail wishlist metadata
- add a focused unit test for German priority labels and document the fix in `CHANGELOG.md`

## Testing
- `dotnet test BookLoggerApp.Tests/BookLoggerApp.Tests.csproj --filter "FullyQualifiedName~WishlistPriorityLocalizationTests"`
- `dotnet build BookLoggerApp.Tests/BookLoggerApp.Tests.csproj`
- `dotnet build BookLoggerApp.Core/BookLoggerApp.Core.csproj`
- `dotnet build BookLoggerApp.Infrastructure/BookLoggerApp.Infrastructure.csproj`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33d6e213-edb4-48d3-a2a0-a801b330d9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33d6e213-edb4-48d3-a2a0-a801b330d9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

