### PR TITLE
Fix missing author validation in add flows

### DIFF
--- a/BookLoggerApp.Core/ViewModels/BookListViewModel.cs
+++ b/BookLoggerApp.Core/ViewModels/BookListViewModel.cs
@@ -40,6 +40,13 @@ public partial class BookListViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(CanAdd))]
     public async Task AddAsync()
     {
+        ClearError();
+        if (!CanAdd())
+        {
+            SetError(Tr("Error_BookTitleAuthorRequired"));
+            return;
+        }
+
         var book = new Book
         {
             Title = NewTitle.Trim(),
@@ -54,12 +61,24 @@ public partial class BookListViewModel : ViewModelBase
         NotifyCanExecuteChanged();
     }
 
-    private bool CanAdd() => !string.IsNullOrWhiteSpace(NewTitle);
+    private bool CanAdd() =>
+        !string.IsNullOrWhiteSpace(NewTitle) &&
+        !string.IsNullOrWhiteSpace(NewAuthor);
 
     private void NotifyCanExecuteChanged()
     {
         // Re-evaluate CanExecute for AddAsync
         AddAsyncCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnNewTitleChanged(string value)
+    {
+        NotifyCanExecuteChanged();
+    }
+
+    partial void OnNewAuthorChanged(string value)
+    {
+        NotifyCanExecuteChanged();
     }
 
     // Add this property to expose the RelayCommand instance for AddAsync

--- a/BookLoggerApp.Core/ViewModels/WishlistViewModel.cs
+++ b/BookLoggerApp.Core/ViewModels/WishlistViewModel.cs
@@ -89,6 +89,12 @@ public partial class WishlistViewModel : ViewModelBase
     {
         await ExecuteSafelyAsync(async () =>
         {
+            if (string.IsNullOrWhiteSpace(NewTitle) || string.IsNullOrWhiteSpace(NewAuthor))
+            {
+                SetError(Tr("Error_BookTitleAuthorRequired"));
+                return;
+            }
+
             var book = new Book
             {
                 Title = NewTitle.Trim(),
@@ -244,6 +250,7 @@ public partial class WishlistViewModel : ViewModelBase
         _lookupCoverUrl = null;
         _lookupDescription = null;
         LookupMessage = null;
+        ErrorMessage = null;
     }
 
     private static bool IsQuotaExceeded(HttpRequestException ex)

--- a/BookLoggerApp.Tests/Unit/ViewModels/BookListViewModelTests.cs
+++ b/BookLoggerApp.Tests/Unit/ViewModels/BookListViewModelTests.cs
@@ -78,9 +78,23 @@ public class BookListViewModelTests
     }
 
     [Fact]
+    public async Task AddAsync_MissingAuthor_SetsErrorAndDoesNotAdd()
+    {
+        _vm.NewTitle = "Brand New";
+        _vm.NewAuthor = "   ";
+
+        await _vm.AddAsync();
+
+        _vm.ErrorMessage.Should().NotBeNullOrEmpty();
+        _vm.Items.Should().BeEmpty();
+        await _bookService.DidNotReceive().AddAsync(Arg.Any<Book>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public void AddCommand_EmptyTitle_CannotExecute()
     {
         _vm.NewTitle = "";
+        _vm.NewAuthor = "Somebody";
 
         _vm.AddAsyncCommand.CanExecute(null).Should().BeFalse();
     }
@@ -89,6 +103,16 @@ public class BookListViewModelTests
     public void AddCommand_WhitespaceTitle_CannotExecute()
     {
         _vm.NewTitle = "   ";
+        _vm.NewAuthor = "Somebody";
+
+        _vm.AddAsyncCommand.CanExecute(null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AddCommand_EmptyAuthor_CannotExecute()
+    {
+        _vm.NewTitle = "Brand New";
+        _vm.NewAuthor = "";
 
         _vm.AddAsyncCommand.CanExecute(null).Should().BeFalse();
     }

--- a/BookLoggerApp.Tests/Unit/ViewModels/WishlistViewModelTests.cs
+++ b/BookLoggerApp.Tests/Unit/ViewModels/WishlistViewModelTests.cs
@@ -90,6 +90,22 @@ public class WishlistViewModelTests
     }
 
     [Fact]
+    public async Task AddToWishlistAsync_MissingAuthor_SetsErrorAndDoesNotCallService()
+    {
+        _vm.NewTitle = "Dune";
+        _vm.NewAuthor = "   ";
+
+        await _vm.AddToWishlistCommand.ExecuteAsync(null);
+
+        _vm.ErrorMessage.Should().NotBeNullOrEmpty();
+        _vm.WishlistBooks.Should().BeEmpty();
+        await _wishlistService.DidNotReceive().AddToWishlistAsync(
+            Arg.Any<Book>(),
+            Arg.Any<WishlistInfo>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task LookupByIsbnAsync_EmptyIsbn_DoesNothing()
     {
         _vm.NewIsbn = "";

--- a/BookLoggerApp/Components/Pages/Bookshelf.razor
+++ b/BookLoggerApp/Components/Pages/Bookshelf.razor
@@ -527,6 +527,10 @@
                         @WishlistVM.LookupMessage
                     </div>
                 }
+                @if (!string.IsNullOrWhiteSpace(WishlistVM.ErrorMessage))
+                {
+                    <div class="alert alert-danger">@WishlistVM.ErrorMessage</div>
+                }
                 <div class="form-group">
                     <label>@L["BookEdit_Title"] *</label>
                     <input type="text" class="form-control" placeholder="@L["Wishlist_TitlePlaceholder"]"
@@ -562,7 +566,7 @@
             <div class="modal-actions">
                 <button class="btn btn-secondary" @onclick="CloseAddToWishlistModal">@L["Common_Cancel"]</button>
                 <button class="btn btn-primary" @onclick="HandleAddToWishlist"
-                        disabled="@(string.IsNullOrWhiteSpace(WishlistVM.NewTitle))">@L["Bookshelf_Add"]</button>
+                        disabled="@(string.IsNullOrWhiteSpace(WishlistVM.NewTitle) || string.IsNullOrWhiteSpace(WishlistVM.NewAuthor))">@L["Bookshelf_Add"]</button>
             </div>
         </div>
     </div>
@@ -1259,9 +1263,8 @@
         if (string.IsNullOrWhiteSpace(WishlistVM.ErrorMessage))
         {
             await OnboardingService.TrackEventAsync(OnboardingEvent.WishlistAdded);
+            CloseAddToWishlistModal();
         }
-
-        CloseAddToWishlistModal();
         StateHasChanged();
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Versionsschema:
 ### Geändert
 - Startgeschwindigkeit verbessert: die veraltete Legacy-Datenbank-Migration (Pfad `Personal` → `LocalApplicationData`) wurde vom Startpfad entfernt. Sie lief bei jedem Kaltstart synchron und durchsuchte das Dateisystem, obwohl alle Bestandsdaten längst am aktuellen Speicherort liegen. Bestehende Daten sind nicht betroffen.
 
+### Behoben
+- Bücher/Wishlist-Einträge lassen sich über die Schnell-Hinzufügen- und Wishlist-Modal-Flows nicht mehr ohne Autor anlegen; der Pflichtfeld-Hinweis wird jetzt in beiden Wegen korrekt erzwungen.
+
 ## [0.11.2]
 
 ### Hinzugefügt


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- require both title and author in the quick-add and wishlist add flows
- keep the wishlist modal open and surface the validation error when author is missing
- add regression tests for both affected viewmodels

## Testing
- `dotnet build BookLoggerApp.Tests/BookLoggerApp.Tests.csproj`
- `dotnet test BookLoggerApp.Tests/BookLoggerApp.Tests.csproj --filter "FullyQualifiedName~BookListViewModelTests|FullyQualifiedName~WishlistViewModelTests"`

## Notes
- The MAUI Android project cannot be built or run in this Cloud Agent VM, so the Razor modal change was validated through targeted Core/test-project builds and the affected viewmodel tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aec183db-99e7-4d18-920e-9bb2af757735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aec183db-99e7-4d18-920e-9bb2af757735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

