### PR TITLE
Fix German onboarding session wording

### DIFF
--- a/BookLoggerApp.Core/Resources/AppResources.de.resx
+++ b/BookLoggerApp.Core/Resources/AppResources.de.resx
@@ -491,10 +491,10 @@
     <value>Buch hinzufügen</value>
   </data>
   <data name="GettingStarted_Mission_LogFirstSession_Title" xml:space="preserve">
-    <value>Erfasse deine erste Lesesession</value>
+    <value>Erfasse deine erste Lesesitzung</value>
   </data>
   <data name="GettingStarted_Mission_LogFirstSession_Description" xml:space="preserve">
-    <value>Starte oder beende eine Lesesession, damit BookHeart Zeit, Seiten, XP und Streaks verfolgen kann.</value>
+    <value>Starte oder beende eine Lesesitzung, damit BookHeart Zeit, Seiten, XP und Streaks verfolgen kann.</value>
   </data>
   <data name="GettingStarted_Mission_LogFirstSession_Cta" xml:space="preserve">
     <value>Bücherregal öffnen</value>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versionsschema:
 ### Behoben
 - Wunschlisten-Prioritäten werden in der Bücherregal-/Wunschlistenansicht jetzt korrekt in der aktiven App-Sprache angezeigt statt als englische Enum-Werte.
 - Bücher/Wishlist-Einträge lassen sich über die Schnell-Hinzufügen- und Wishlist-Modal-Flows nicht mehr ohne Autor anlegen; der Pflichtfeld-Hinweis wird jetzt in beiden Wegen korrekt erzwungen.
+- Die Onboarding-Mission für die erste geloggte Lesezeit verwendet in der deutschen UI jetzt konsistent den Begriff „Lesesitzung“ statt „Lesesession“.
 
 ## [0.11.2]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the German onboarding mission wording from `Lesesession` to `Lesesitzung`
- add a changelog entry for the localization consistency fix

## Testing
- `dotnet build BookLoggerApp.Core/BookLoggerApp.Core.csproj`
- `dotnet test BookLoggerApp.Tests/BookLoggerApp.Tests.csproj --filter "FullyQualifiedName~AppResourcesCoverageTests"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1530b9f-d999-4df0-89ff-a48c748a4e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1530b9f-d999-4df0-89ff-a48c748a4e83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

