### PR TITLE
Add Blind Date with a Book (Sub-TBR Roulette) feature

### DIFF
--- a/BookLoggerApp.Core/Enums/BlindDateRevealAnimation.cs
+++ b/BookLoggerApp.Core/Enums/BlindDateRevealAnimation.cs
@@ -1,0 +1,14 @@
+namespace BookLoggerApp.Core.Enums;
+
+/// <summary>
+/// The reveal animation played when a Blind Date card is unwrapped. One of these is
+/// chosen at random on every reveal so the moment feels varied.
+/// </summary>
+public enum BlindDateRevealAnimation
+{
+    /// <summary>Wrapping paper peels open along the ribbon and the bow pops off.</summary>
+    Unwrap = 0,
+
+    /// <summary>The card shakes with tension, then the wrapping bursts away.</summary>
+    Burst = 1
+}

--- a/BookLoggerApp.Core/Models/BlindDateCandidate.cs
+++ b/BookLoggerApp.Core/Models/BlindDateCandidate.cs
@@ -1,0 +1,21 @@
+namespace BookLoggerApp.Core.Models;
+
+/// <summary>
+/// A single "wrapped" card in the Blind Date roulette: the underlying <see cref="Book"/>
+/// plus the 3–4 vibe tags shown to the user while the cover and title stay hidden.
+/// Vibes are trope names; when a book has no tropes, the genre name(s) are used as a
+/// fallback (flagged via <see cref="IsGenreFallback"/>). Trope and genre names are shown
+/// verbatim — they are deliberately not localized.
+/// </summary>
+public class BlindDateCandidate
+{
+    public Book Book { get; init; } = null!;
+
+    public IReadOnlyList<string> Vibes { get; init; } = new List<string>();
+
+    /// <summary>
+    /// True when <see cref="Vibes"/> were derived from the book's genre(s) (or a generic
+    /// placeholder) because the book has no tropes assigned.
+    /// </summary>
+    public bool IsGenreFallback { get; init; }
+}

--- a/BookLoggerApp.Core/Resources/AppResources.de.resx
+++ b/BookLoggerApp.Core/Resources/AppResources.de.resx
@@ -3139,4 +3139,49 @@
   <data name="Feature_FamilySharing_Description" xml:space="preserve">
     <value>Teile dein Premium-Abo mit bis zu 5 Familienmitgliedern.</value>
   </data>
+  <data name="PageTitle_BlindDate" xml:space="preserve">
+    <value>Blind Date</value>
+  </data>
+  <data name="BlindDate_EntryButton" xml:space="preserve">
+    <value>Blind Date</value>
+  </data>
+  <data name="BlindDate_Title" xml:space="preserve">
+    <value>Blind Date mit einem Buch</value>
+  </data>
+  <data name="BlindDate_Subtitle" xml:space="preserve">
+    <value>Wähle nach den Vibes — das Cover bleibt geheim, bis du es auspackst.</value>
+  </data>
+  <data name="BlindDate_PickPrompt" xml:space="preserve">
+    <value>Welcher Vibe spricht dich an?</value>
+  </data>
+  <data name="BlindDate_Shuffle" xml:space="preserve">
+    <value>Neu mischen</value>
+  </data>
+  <data name="BlindDate_CardHint" xml:space="preserve">
+    <value>Zum Auspacken tippen</value>
+  </data>
+  <data name="BlindDate_RevealHeader" xml:space="preserve">
+    <value>Dein Blind Date ist…</value>
+  </data>
+  <data name="BlindDate_ViewBook" xml:space="preserve">
+    <value>Buch ansehen</value>
+  </data>
+  <data name="BlindDate_PickAnother" xml:space="preserve">
+    <value>Nochmal</value>
+  </data>
+  <data name="BlindDate_MysteryVibe" xml:space="preserve">
+    <value>Ein völliges Geheimnis</value>
+  </data>
+  <data name="BlindDate_Empty_Title" xml:space="preserve">
+    <value>Noch nichts zum Auspacken</value>
+  </data>
+  <data name="BlindDate_Empty_Body" xml:space="preserve">
+    <value>Füge Bücher zu deinem TBR oder deiner Wishlist hinzu, um ein Blind Date zu starten.</value>
+  </data>
+  <data name="BlindDate_Empty_Cta" xml:space="preserve">
+    <value>Zum Regal</value>
+  </data>
+  <data name="Error_FailedTo_LoadBlindDate" xml:space="preserve">
+    <value>Blind Date konnte nicht geladen werden</value>
+  </data>
 </root>

--- a/BookLoggerApp.Core/Resources/AppResources.resx
+++ b/BookLoggerApp.Core/Resources/AppResources.resx
@@ -3198,4 +3198,49 @@
   <data name="Feature_FamilySharing_Description" xml:space="preserve">
     <value>Share your Premium subscription with up to 5 family members.</value>
   </data>
+  <data name="PageTitle_BlindDate" xml:space="preserve">
+    <value>Blind Date</value>
+  </data>
+  <data name="BlindDate_EntryButton" xml:space="preserve">
+    <value>Blind Date</value>
+  </data>
+  <data name="BlindDate_Title" xml:space="preserve">
+    <value>Blind Date with a Book</value>
+  </data>
+  <data name="BlindDate_Subtitle" xml:space="preserve">
+    <value>Pick by the vibes — the cover stays secret until you unwrap it.</value>
+  </data>
+  <data name="BlindDate_PickPrompt" xml:space="preserve">
+    <value>Which vibe speaks to you?</value>
+  </data>
+  <data name="BlindDate_Shuffle" xml:space="preserve">
+    <value>Shuffle</value>
+  </data>
+  <data name="BlindDate_CardHint" xml:space="preserve">
+    <value>Tap to unwrap</value>
+  </data>
+  <data name="BlindDate_RevealHeader" xml:space="preserve">
+    <value>Your blind date is…</value>
+  </data>
+  <data name="BlindDate_ViewBook" xml:space="preserve">
+    <value>View book</value>
+  </data>
+  <data name="BlindDate_PickAnother" xml:space="preserve">
+    <value>Pick another</value>
+  </data>
+  <data name="BlindDate_MysteryVibe" xml:space="preserve">
+    <value>A total mystery</value>
+  </data>
+  <data name="BlindDate_Empty_Title" xml:space="preserve">
+    <value>Nothing to unwrap yet</value>
+  </data>
+  <data name="BlindDate_Empty_Body" xml:space="preserve">
+    <value>Add books to your TBR or wishlist to start a blind date.</value>
+  </data>
+  <data name="BlindDate_Empty_Cta" xml:space="preserve">
+    <value>Go to bookshelf</value>
+  </data>
+  <data name="Error_FailedTo_LoadBlindDate" xml:space="preserve">
+    <value>Failed to load blind date</value>
+  </data>
 </root>

--- a/BookLoggerApp.Core/Services/Abstractions/IBlindDateService.cs
+++ b/BookLoggerApp.Core/Services/Abstractions/IBlindDateService.cs
@@ -1,0 +1,19 @@
+using BookLoggerApp.Core.Models;
+
+namespace BookLoggerApp.Core.Services.Abstractions;
+
+/// <summary>
+/// Service for the "Blind Date with a Book" (Sub-TBR Roulette) feature. Provides the
+/// pool of unread candidate books — eager-loaded with their tropes and genres — that
+/// the UI presents as "wrapped" cards showing only the vibes (tropes) of each book.
+/// </summary>
+public interface IBlindDateService
+{
+    /// <summary>
+    /// Returns the candidate books for a blind date: everything the user has not read
+    /// yet (<see cref="ReadingStatus.Planned"/> TBR + <see cref="ReadingStatus.Wishlist"/>),
+    /// with <c>BookTropes.Trope</c> and <c>BookGenres.Genre</c> included so the caller can
+    /// build the vibe cards without further round-trips.
+    /// </summary>
+    Task<IReadOnlyList<Book>> GetCandidatesAsync(CancellationToken ct = default);
+}

--- a/BookLoggerApp.Core/ViewModels/BlindDateViewModel.cs
+++ b/BookLoggerApp.Core/ViewModels/BlindDateViewModel.cs
@@ -1,0 +1,126 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using BookLoggerApp.Core.Models;
+using BookLoggerApp.Core.Services.Abstractions;
+
+namespace BookLoggerApp.Core.ViewModels;
+
+/// <summary>
+/// VM for the "Blind Date with a Book" (Sub-TBR Roulette) feature. Loads the unread
+/// book pool (TBR + Wishlist), presents a small random set of "wrapped" cards showing
+/// only each book's vibes (tropes, or genre as fallback), and reveals the chosen book.
+/// </summary>
+public partial class BlindDateViewModel : ViewModelBase
+{
+    private const int CardsPerRound = 3;
+    private const int MaxVibes = 4;
+
+    private readonly IBlindDateService _blindDateService;
+
+    private List<Book> _allCandidates = new();
+
+    /// <summary>The "wrapped" cards currently offered to the user to pick from.</summary>
+    public ObservableCollection<BlindDateCandidate> ShownCards { get; } = new();
+
+    /// <summary>True once there is at least one eligible book in the pool.</summary>
+    [ObservableProperty]
+    private bool _hasCandidates;
+
+    /// <summary>The book that was unwrapped, or <c>null</c> while still picking.</summary>
+    [ObservableProperty]
+    private Book? _revealedBook;
+
+    [ObservableProperty]
+    private bool _hasRevealed;
+
+    public BlindDateViewModel(IBlindDateService blindDateService)
+    {
+        _blindDateService = blindDateService;
+    }
+
+    [RelayCommand]
+    public async Task LoadAsync()
+    {
+        await ExecuteSafelyWithDbAsync(async () =>
+        {
+            var books = await _blindDateService.GetCandidatesAsync();
+            _allCandidates = books.ToList();
+            HasCandidates = _allCandidates.Count > 0;
+            HasRevealed = false;
+            RevealedBook = null;
+            DrawCards();
+        }, Tr("Error_FailedTo_LoadBlindDate"));
+    }
+
+    /// <summary>Draws a fresh random set of wrapped cards from the pool.</summary>
+    public void Shuffle()
+    {
+        HasRevealed = false;
+        RevealedBook = null;
+        DrawCards();
+    }
+
+    /// <summary>Unwraps the picked card and reveals its book.</summary>
+    public void Reveal(BlindDateCandidate? card)
+    {
+        if (card is null)
+        {
+            return;
+        }
+
+        RevealedBook = card.Book;
+        HasRevealed = true;
+    }
+
+    /// <summary>Returns from the reveal back to the current selection of cards.</summary>
+    public void PickAnother()
+    {
+        HasRevealed = false;
+        RevealedBook = null;
+    }
+
+    private void DrawCards()
+    {
+        ShownCards.Clear();
+        foreach (var book in _allCandidates.OrderBy(_ => Random.Shared.Next()).Take(CardsPerRound))
+        {
+            ShownCards.Add(BuildCandidate(book));
+        }
+    }
+
+    private BlindDateCandidate BuildCandidate(Book book)
+    {
+        var tropeNames = book.BookTropes
+            .Select(bt => bt.Trope?.Name)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name!)
+            .Distinct()
+            .ToList();
+
+        if (tropeNames.Count > 0)
+        {
+            var vibes = tropeNames
+                .OrderBy(_ => Random.Shared.Next())
+                .Take(MaxVibes)
+                .ToList();
+            return new BlindDateCandidate { Book = book, Vibes = vibes, IsGenreFallback = false };
+        }
+
+        // Fallback: show the genre(s) when the book has no tropes.
+        var genreNames = book.BookGenres
+            .Select(bg => bg.Genre?.Name)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name!)
+            .Distinct()
+            .Take(MaxVibes)
+            .ToList();
+
+        if (genreNames.Count == 0)
+        {
+            genreNames.Add(Tr("BlindDate_MysteryVibe"));
+        }
+
+        return new BlindDateCandidate { Book = book, Vibes = genreNames, IsGenreFallback = true };
+    }
+}

--- a/BookLoggerApp.Core/ViewModels/BlindDateViewModel.cs
+++ b/BookLoggerApp.Core/ViewModels/BlindDateViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using BookLoggerApp.Core.Enums;
 using BookLoggerApp.Core.Models;
 using BookLoggerApp.Core.Services.Abstractions;
 
@@ -33,6 +34,10 @@ public partial class BlindDateViewModel : ViewModelBase
 
     [ObservableProperty]
     private bool _hasRevealed;
+
+    /// <summary>The animation variant for the current reveal (chosen at random per reveal).</summary>
+    [ObservableProperty]
+    private BlindDateRevealAnimation _revealAnimation;
 
     public BlindDateViewModel(IBlindDateService blindDateService)
     {
@@ -69,6 +74,10 @@ public partial class BlindDateViewModel : ViewModelBase
             return;
         }
 
+        // Pick one of the two reveal animations at random for variety.
+        RevealAnimation = Random.Shared.Next(2) == 0
+            ? BlindDateRevealAnimation.Unwrap
+            : BlindDateRevealAnimation.Burst;
         RevealedBook = card.Book;
         HasRevealed = true;
     }

--- a/BookLoggerApp.Infrastructure/Services/BlindDateService.cs
+++ b/BookLoggerApp.Infrastructure/Services/BlindDateService.cs
@@ -1,0 +1,32 @@
+using BookLoggerApp.Core.Models;
+using BookLoggerApp.Core.Services.Abstractions;
+using BookLoggerApp.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookLoggerApp.Infrastructure.Services;
+
+/// <summary>
+/// Service implementation for the "Blind Date with a Book" feature.
+/// Uses DbContextFactory for thread-safe read operations (same pattern as WishlistService).
+/// </summary>
+public class BlindDateService : IBlindDateService
+{
+    private readonly IDbContextFactory<AppDbContext> _contextFactory;
+
+    public BlindDateService(IDbContextFactory<AppDbContext> contextFactory)
+    {
+        _contextFactory = contextFactory;
+    }
+
+    public async Task<IReadOnlyList<Book>> GetCandidatesAsync(CancellationToken ct = default)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(ct);
+        return await context.Books
+            .Include(b => b.BookTropes)
+                .ThenInclude(bt => bt.Trope)
+            .Include(b => b.BookGenres)
+                .ThenInclude(bg => bg.Genre)
+            .Where(b => b.Status == ReadingStatus.Planned || b.Status == ReadingStatus.Wishlist)
+            .ToListAsync(ct);
+    }
+}

--- a/BookLoggerApp.Tests/Services/BlindDateServiceTests.cs
+++ b/BookLoggerApp.Tests/Services/BlindDateServiceTests.cs
@@ -1,0 +1,102 @@
+using BookLoggerApp.Core.Models;
+using BookLoggerApp.Infrastructure.Services;
+using BookLoggerApp.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace BookLoggerApp.Tests.Services;
+
+public class BlindDateServiceTests : IDisposable
+{
+    private readonly TestDbContextFactory _factory;
+    private readonly BlindDateService _service;
+
+    public BlindDateServiceTests()
+    {
+        _factory = new TestDbContextFactory(Guid.NewGuid().ToString());
+        _service = new BlindDateService(_factory);
+    }
+
+    public void Dispose()
+    {
+        using var ctx = _factory.CreateDbContext();
+        ctx.Database.EnsureDeleted();
+    }
+
+    private async Task SeedBookAsync(string title, ReadingStatus status, string[]? tropeNames = null, string[]? genreNames = null)
+    {
+        await using var ctx = _factory.CreateDbContext();
+        var book = new Book { Title = title, Author = "Author", Status = status };
+        ctx.Books.Add(book);
+
+        if (tropeNames is not null)
+        {
+            foreach (var name in tropeNames)
+            {
+                var trope = new Trope { Id = Guid.NewGuid(), Name = name, GenreId = Guid.NewGuid() };
+                ctx.Tropes.Add(trope);
+                ctx.BookTropes.Add(new BookTrope { BookId = book.Id, TropeId = trope.Id });
+            }
+        }
+
+        if (genreNames is not null)
+        {
+            foreach (var name in genreNames)
+            {
+                var genre = new Genre { Id = Guid.NewGuid(), Name = name };
+                ctx.Genres.Add(genre);
+                ctx.BookGenres.Add(new BookGenre { BookId = book.Id, GenreId = genre.Id });
+            }
+        }
+
+        await ctx.SaveChangesAsync();
+    }
+
+    [Fact]
+    public async Task GetCandidatesAsync_ReturnsPlannedAndWishlist_ExcludesRead()
+    {
+        await SeedBookAsync("Planned", ReadingStatus.Planned);
+        await SeedBookAsync("Wishlist", ReadingStatus.Wishlist);
+        await SeedBookAsync("Reading", ReadingStatus.Reading);
+        await SeedBookAsync("Completed", ReadingStatus.Completed);
+        await SeedBookAsync("Abandoned", ReadingStatus.Abandoned);
+
+        var result = await _service.GetCandidatesAsync();
+
+        result.Select(b => b.Title).Should().BeEquivalentTo("Planned", "Wishlist");
+    }
+
+    [Fact]
+    public async Task GetCandidatesAsync_EagerLoadsTropes()
+    {
+        await SeedBookAsync("Vibes", ReadingStatus.Planned, tropeNames: new[] { "Slow Burn", "Enemies to Lovers" });
+
+        var result = await _service.GetCandidatesAsync();
+
+        result.Should().HaveCount(1);
+        result[0].BookTropes.Select(bt => bt.Trope.Name)
+            .Should().BeEquivalentTo("Slow Burn", "Enemies to Lovers");
+    }
+
+    [Fact]
+    public async Task GetCandidatesAsync_EagerLoadsGenres()
+    {
+        await SeedBookAsync("Genred", ReadingStatus.Wishlist, genreNames: new[] { "Fantasy" });
+
+        var result = await _service.GetCandidatesAsync();
+
+        result.Should().HaveCount(1);
+        result[0].BookGenres.Select(bg => bg.Genre.Name).Should().ContainSingle().Which.Should().Be("Fantasy");
+    }
+
+    [Fact]
+    public async Task GetCandidatesAsync_ReturnsEmpty_WhenNoUnreadBooks()
+    {
+        await SeedBookAsync("Reading", ReadingStatus.Reading);
+        await SeedBookAsync("Completed", ReadingStatus.Completed);
+
+        var result = await _service.GetCandidatesAsync();
+
+        result.Should().BeEmpty();
+    }
+}

--- a/BookLoggerApp.Tests/Unit/ViewModels/BlindDateViewModelTests.cs
+++ b/BookLoggerApp.Tests/Unit/ViewModels/BlindDateViewModelTests.cs
@@ -1,3 +1,4 @@
+using BookLoggerApp.Core.Enums;
 using BookLoggerApp.Core.Infrastructure;
 using BookLoggerApp.Core.Models;
 using BookLoggerApp.Core.Services.Abstractions;
@@ -177,5 +178,34 @@ public class BlindDateViewModelTests
 
         _vm.HasRevealed.Should().BeFalse();
         _vm.RevealedBook.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Reveal_SetsAValidRevealAnimation()
+    {
+        SetupCandidates(BookWith("A"));
+        await _vm.LoadCommand.ExecuteAsync(null);
+
+        _vm.Reveal(_vm.ShownCards.Single());
+
+        _vm.RevealAnimation.Should().BeOneOf(BlindDateRevealAnimation.Unwrap, BlindDateRevealAnimation.Burst);
+    }
+
+    [Fact]
+    public async Task Reveal_RandomlyUsesBothAnimationVariants()
+    {
+        SetupCandidates(BookWith("A"));
+        await _vm.LoadCommand.ExecuteAsync(null);
+        var card = _vm.ShownCards.Single();
+
+        var seen = new HashSet<BlindDateRevealAnimation>();
+        for (int i = 0; i < 60; i++)
+        {
+            _vm.Reveal(card);
+            seen.Add(_vm.RevealAnimation);
+        }
+
+        // Over 60 draws both variants are essentially certain to appear.
+        seen.Should().Contain(new[] { BlindDateRevealAnimation.Unwrap, BlindDateRevealAnimation.Burst });
     }
 }

--- a/BookLoggerApp.Tests/Unit/ViewModels/BlindDateViewModelTests.cs
+++ b/BookLoggerApp.Tests/Unit/ViewModels/BlindDateViewModelTests.cs
@@ -1,0 +1,181 @@
+using BookLoggerApp.Core.Infrastructure;
+using BookLoggerApp.Core.Models;
+using BookLoggerApp.Core.Services.Abstractions;
+using BookLoggerApp.Core.ViewModels;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace BookLoggerApp.Tests.Unit.ViewModels;
+
+public class BlindDateViewModelTests
+{
+    private readonly IBlindDateService _service;
+    private readonly BlindDateViewModel _vm;
+
+    public BlindDateViewModelTests()
+    {
+        DatabaseInitializationHelper.MarkAsInitialized();
+        _service = Substitute.For<IBlindDateService>();
+        _service.GetCandidatesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Book>>(new List<Book>()));
+        _vm = new BlindDateViewModel(_service);
+    }
+
+    private static Book BookWith(string title, string[]? tropes = null, string[]? genres = null)
+    {
+        var book = new Book { Id = Guid.NewGuid(), Title = title, Author = "Author" };
+
+        if (tropes is not null)
+        {
+            foreach (var name in tropes)
+            {
+                book.BookTropes.Add(new BookTrope
+                {
+                    BookId = book.Id,
+                    TropeId = Guid.NewGuid(),
+                    Trope = new Trope { Name = name }
+                });
+            }
+        }
+
+        if (genres is not null)
+        {
+            foreach (var name in genres)
+            {
+                book.BookGenres.Add(new BookGenre
+                {
+                    BookId = book.Id,
+                    GenreId = Guid.NewGuid(),
+                    Genre = new Genre { Name = name }
+                });
+            }
+        }
+
+        return book;
+    }
+
+    private void SetupCandidates(params Book[] books)
+    {
+        _service.GetCandidatesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<Book>>(books.ToList()));
+    }
+
+    [Fact]
+    public async Task LoadAsync_PopulatesCards_WhenCandidatesExist()
+    {
+        SetupCandidates(
+            BookWith("A", tropes: new[] { "Slow Burn" }),
+            BookWith("B", tropes: new[] { "Mafia" }));
+
+        await _vm.LoadCommand.ExecuteAsync(null);
+
+        _vm.HasCandidates.Should().BeTrue();
+        _vm.ShownCards.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task LoadAsync_LimitsShownCardsToThree()
+    {
+        SetupCandidates(
+            BookWith("A"), BookWith("B"), BookWith("C"), BookWith("D"), BookWith("E"));
+
+        await _vm.LoadCommand.ExecuteAsync(null);
+
+        _vm.ShownCards.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task LoadAsync_SetsHasCandidatesFalse_WhenEmpty()
+    {
+        await _vm.LoadCommand.ExecuteAsync(null);
+
+        _vm.HasCandidates.Should().BeFalse();
+        _vm.ShownCards.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task LoadAsync_UsesTropeNamesAsVibes()
+    {
+        SetupCandidates(BookWith("A", tropes: new[] { "Enemies to Lovers", "Slow Burn" }));
+
+        await _vm.LoadCommand.ExecuteAsync(null);
+
+        var card = _vm.ShownCards.Single();
+        card.IsGenreFallback.Should().BeFalse();
+        card.Vibes.Should().BeEquivalentTo("Enemies to Lovers", "Slow Burn");
+    }
+
+    [Fact]
+    public async Task LoadAsync_FallsBackToGenre_WhenNoTropes()
+    {
+        SetupCandidates(BookWith("A", genres: new[] { "Fantasy" }));
+
+        await _vm.LoadCommand.ExecuteAsync(null);
+
+        var card = _vm.ShownCards.Single();
+        card.IsGenreFallback.Should().BeTrue();
+        card.Vibes.Should().ContainSingle().Which.Should().Be("Fantasy");
+    }
+
+    [Fact]
+    public async Task LoadAsync_CapsVibesAtFour()
+    {
+        SetupCandidates(BookWith("A", tropes: new[]
+        {
+            "T1", "T2", "T3", "T4", "T5", "T6"
+        }));
+
+        await _vm.LoadCommand.ExecuteAsync(null);
+
+        _vm.ShownCards.Single().Vibes.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public async Task LoadAsync_UsesMysteryVibe_WhenNoTropesAndNoGenres()
+    {
+        SetupCandidates(BookWith("A"));
+
+        await _vm.LoadCommand.ExecuteAsync(null);
+
+        var card = _vm.ShownCards.Single();
+        card.IsGenreFallback.Should().BeTrue();
+        // No tropes and no genres → exactly one localized fallback "mystery" vibe.
+        card.Vibes.Should().ContainSingle().Which.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Reveal_SetsRevealedBookAndFlag()
+    {
+        SetupCandidates(BookWith("A", tropes: new[] { "Slow Burn" }));
+        await _vm.LoadCommand.ExecuteAsync(null);
+        var card = _vm.ShownCards.Single();
+
+        _vm.Reveal(card);
+
+        _vm.HasRevealed.Should().BeTrue();
+        _vm.RevealedBook.Should().BeSameAs(card.Book);
+    }
+
+    [Fact]
+    public async Task PickAnother_ClearsReveal()
+    {
+        SetupCandidates(BookWith("A"));
+        await _vm.LoadCommand.ExecuteAsync(null);
+        _vm.Reveal(_vm.ShownCards.Single());
+
+        _vm.PickAnother();
+
+        _vm.HasRevealed.Should().BeFalse();
+        _vm.RevealedBook.Should().BeNull();
+    }
+
+    [Fact]
+    public void Reveal_Ignores_Null()
+    {
+        _vm.Reveal(null);
+
+        _vm.HasRevealed.Should().BeFalse();
+        _vm.RevealedBook.Should().BeNull();
+    }
+}

--- a/BookLoggerApp/Components/Pages/BlindDate.razor
+++ b/BookLoggerApp/Components/Pages/BlindDate.razor
@@ -1,0 +1,175 @@
+@page "/blind-date"
+@using BookLoggerApp.Core.ViewModels
+@using BookLoggerApp.Core.Models
+@using BookLoggerApp.Core.Resources
+@using BookLoggerApp.Core.Services.Abstractions
+@using BookLoggerApp.Components.Shared
+@using Microsoft.Extensions.Localization
+@inject BlindDateViewModel ViewModel
+@inject Microsoft.AspNetCore.Components.NavigationManager Navigation
+@inject IImageService ImageService
+@inject IStringLocalizer<AppResources> L
+@inherits BookLoggerApp.Components.ObservableComponentBase
+
+<PageTitle>@L["PageTitle_BlindDate"] - BookHeart</PageTitle>
+
+<div class="blinddate-container">
+    <div class="blinddate-hero">
+        <h1>🎁 @L["BlindDate_Title"]</h1>
+        <p class="blinddate-subtitle">@L["BlindDate_Subtitle"]</p>
+    </div>
+
+    @if (ViewModel.IsBusy)
+    {
+        <div class="loading-state">
+            <div class="loading-spinner"></div>
+        </div>
+    }
+    else if (!string.IsNullOrEmpty(ViewModel.ErrorMessage))
+    {
+        <div class="error-state">
+            <p>@ViewModel.ErrorMessage</p>
+            <button class="btn btn-primary" @onclick="ReloadAsync">@L["Common_Retry"]</button>
+        </div>
+    }
+    else if (!ViewModel.HasCandidates)
+    {
+        <div class="blinddate-empty">
+            <div class="blinddate-empty-icon">📚</div>
+            <h2>@L["BlindDate_Empty_Title"]</h2>
+            <p>@L["BlindDate_Empty_Body"]</p>
+            <button class="btn btn-primary" @onclick="GoToBookshelf">@L["BlindDate_Empty_Cta"]</button>
+        </div>
+    }
+    else if (ViewModel.HasRevealed && ViewModel.RevealedBook is not null)
+    {
+        <div class="blinddate-reveal">
+            <div class="blinddate-reveal-card">
+                @for (int i = 0; i < 12; i++)
+                {
+                    <div class="confetti"></div>
+                }
+                <p class="blinddate-reveal-header">@L["BlindDate_RevealHeader"]</p>
+                <div class="blinddate-reveal-cover">
+                    @if (!string.IsNullOrEmpty(_revealCoverUrl))
+                    {
+                        <img src="@_revealCoverUrl" alt="@ViewModel.RevealedBook.Title" />
+                    }
+                    else
+                    {
+                        <span class="blinddate-no-cover">📖</span>
+                    }
+                </div>
+                <h2 class="blinddate-reveal-title">@ViewModel.RevealedBook.Title</h2>
+                <p class="blinddate-reveal-author">@ViewModel.RevealedBook.Author</p>
+                <div class="blinddate-reveal-actions">
+                    <button class="btn btn-primary" @onclick="ViewBook">@L["BlindDate_ViewBook"]</button>
+                    <button class="btn btn-secondary" @onclick="PickAnother">@L["BlindDate_PickAnother"]</button>
+                </div>
+            </div>
+        </div>
+    }
+    else
+    {
+        <p class="blinddate-prompt">@L["BlindDate_PickPrompt"]</p>
+        <div class="blinddate-card-grid">
+            @foreach (var card in ViewModel.ShownCards)
+            {
+                <BlindDateCard Vibes="card.Vibes"
+                               IsGenreFallback="card.IsGenreFallback"
+                               OnPick="() => HandlePickAsync(card)" />
+            }
+        </div>
+        <div class="blinddate-shuffle">
+            <button class="btn btn-secondary" @onclick="Shuffle">🔀 @L["BlindDate_Shuffle"]</button>
+        </div>
+    }
+</div>
+
+@code {
+    private string? _revealCoverUrl;
+
+    protected override async Task OnInitializedAsync()
+    {
+        Observe(ViewModel);
+        await ViewModel.LoadCommand.ExecuteAsync(null);
+    }
+
+    private async Task ReloadAsync()
+    {
+        _revealCoverUrl = null;
+        await ViewModel.LoadCommand.ExecuteAsync(null);
+    }
+
+    private async Task HandlePickAsync(BlindDateCandidate card)
+    {
+        ViewModel.Reveal(card);
+        await LoadRevealCoverAsync();
+    }
+
+    private void Shuffle()
+    {
+        _revealCoverUrl = null;
+        ViewModel.Shuffle();
+    }
+
+    private void PickAnother()
+    {
+        _revealCoverUrl = null;
+        ViewModel.PickAnother();
+    }
+
+    private void ViewBook()
+    {
+        if (ViewModel.RevealedBook is not null)
+        {
+            Navigation.NavigateTo($"/books/{ViewModel.RevealedBook.Id}");
+        }
+    }
+
+    private void GoToBookshelf()
+    {
+        Navigation.NavigateTo("/bookshelf");
+    }
+
+    private async Task LoadRevealCoverAsync()
+    {
+        _revealCoverUrl = null;
+        var book = ViewModel.RevealedBook;
+        if (book is null || string.IsNullOrEmpty(book.CoverImagePath))
+        {
+            return;
+        }
+
+        try
+        {
+            var coverPath = book.CoverImagePath;
+
+            // Remote URLs can be used directly.
+            if (coverPath.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+                coverPath.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                _revealCoverUrl = coverPath;
+                return;
+            }
+
+            var fullPath = await ImageService.GetCoverImagePathAsync(book.Id);
+            if (string.IsNullOrEmpty(fullPath) || !System.IO.File.Exists(fullPath))
+            {
+                return;
+            }
+
+            var imageBytes = await System.IO.File.ReadAllBytesAsync(fullPath);
+            var base64 = Convert.ToBase64String(imageBytes);
+            var mimeType = fullPath.EndsWith(".png", StringComparison.OrdinalIgnoreCase)
+                ? "image/png"
+                : "image/jpeg";
+            _revealCoverUrl = $"data:{mimeType};base64,{base64}";
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to load blind date cover: {ex.Message}");
+            _revealCoverUrl = null;
+        }
+    }
+}

--- a/BookLoggerApp/Components/Pages/BlindDate.razor
+++ b/BookLoggerApp/Components/Pages/BlindDate.razor
@@ -43,7 +43,7 @@
     }
     else if (ViewModel.HasRevealed && ViewModel.RevealedBook is not null)
     {
-        <div class="blinddate-reveal">
+        <div class="blinddate-reveal reveal-@(ViewModel.RevealAnimation.ToString().ToLowerInvariant())">
             <div class="blinddate-reveal-card">
                 @for (int i = 0; i < 12; i++)
                 {
@@ -59,6 +59,13 @@
                     {
                         <span class="blinddate-no-cover">📖</span>
                     }
+                    @* Gift-wrap overlay — animates away (unwrap or burst) to reveal the cover *@
+                    <div class="blinddate-wrap-overlay">
+                        <div class="wrap-half wrap-left"></div>
+                        <div class="wrap-half wrap-right"></div>
+                        <div class="wrap-ribbon"></div>
+                        <div class="wrap-bow">🎀</div>
+                    </div>
                 </div>
                 <h2 class="blinddate-reveal-title">@ViewModel.RevealedBook.Title</h2>
                 <p class="blinddate-reveal-author">@ViewModel.RevealedBook.Author</p>

--- a/BookLoggerApp/Components/Pages/BlindDate.razor
+++ b/BookLoggerApp/Components/Pages/BlindDate.razor
@@ -45,7 +45,7 @@
     {
         <div class="blinddate-reveal reveal-@(ViewModel.RevealAnimation.ToString().ToLowerInvariant())">
             <div class="blinddate-reveal-card">
-                @for (int i = 0; i < 12; i++)
+                @for (int i = 0; i < 18; i++)
                 {
                     <div class="confetti"></div>
                 }
@@ -84,22 +84,25 @@
     else
     {
         <p class="blinddate-prompt">@L["BlindDate_PickPrompt"]</p>
-        <div class="blinddate-card-grid">
+        <div class="blinddate-card-grid @(_isShuffling ? "shuffling" : "")">
             @foreach (var card in ViewModel.ShownCards)
             {
-                <BlindDateCard Vibes="card.Vibes"
+                <BlindDateCard @key="(_shuffleNonce, card.Book.Id)"
+                               Vibes="card.Vibes"
                                IsGenreFallback="card.IsGenreFallback"
                                OnPick="() => HandlePickAsync(card)" />
             }
         </div>
         <div class="blinddate-shuffle">
-            <button class="btn btn-secondary" @onclick="Shuffle">🔀 @L["BlindDate_Shuffle"]</button>
+            <button class="btn btn-secondary" @onclick="Shuffle" disabled="@_isShuffling">🔀 @L["BlindDate_Shuffle"]</button>
         </div>
     }
 </div>
 
 @code {
     private string? _revealCoverUrl;
+    private bool _isShuffling;
+    private int _shuffleNonce;
 
     protected override async Task OnInitializedAsync()
     {
@@ -119,10 +122,25 @@
         await LoadRevealCoverAsync();
     }
 
-    private void Shuffle()
+    private async Task Shuffle()
     {
+        if (_isShuffling)
+        {
+            return;
+        }
+
+        // Play the "gather out" animation on the current cards…
+        _isShuffling = true;
+        StateHasChanged();
+        await Task.Delay(450);
+
+        // …then swap in a fresh set. Bumping the nonce changes each card's @key,
+        // so Blazor re-creates the DOM and the "deal in" animation replays.
         _revealCoverUrl = null;
         ViewModel.Shuffle();
+        _shuffleNonce++;
+        _isShuffling = false;
+        StateHasChanged();
     }
 
     private void PickAnother()

--- a/BookLoggerApp/Components/Pages/BlindDate.razor
+++ b/BookLoggerApp/Components/Pages/BlindDate.razor
@@ -57,7 +57,8 @@
                     }
                     else
                     {
-                        <span class="blinddate-no-cover">📖</span>
+                        @* No cover image: write the title into the cover box itself. *@
+                        <span class="blinddate-cover-title">@ViewModel.RevealedBook.Title</span>
                     }
                     @* Gift-wrap overlay — animates away (unwrap or burst) to reveal the cover *@
                     <div class="blinddate-wrap-overlay">
@@ -67,7 +68,11 @@
                         <div class="wrap-bow">🎀</div>
                     </div>
                 </div>
-                <h2 class="blinddate-reveal-title">@ViewModel.RevealedBook.Title</h2>
+                @if (!string.IsNullOrEmpty(_revealCoverUrl))
+                {
+                    @* Title shown below only when a cover image stands in the box above. *@
+                    <h2 class="blinddate-reveal-title">@ViewModel.RevealedBook.Title</h2>
+                }
                 <p class="blinddate-reveal-author">@ViewModel.RevealedBook.Author</p>
                 <div class="blinddate-reveal-actions">
                     <button class="btn btn-primary" @onclick="ViewBook">@L["BlindDate_ViewBook"]</button>

--- a/BookLoggerApp/Components/Pages/Bookshelf.razor
+++ b/BookLoggerApp/Components/Pages/Bookshelf.razor
@@ -46,13 +46,9 @@
                 <span class="wishlist-count-badge">@WishlistVM.WishlistCount</span>
             }
         </button>
-    </div>
-
-    <!-- Blind Date with a Book (Sub-TBR Roulette) entry -->
-    <div class="blinddate-entry">
-        <button class="blinddate-entry-btn" @onclick='() => Navigation.NavigateTo("/blind-date")'>
-            🎁 @L["BlindDate_EntryButton"]
-        </button>
+        <!-- Blind Date with a Book (Sub-TBR Roulette) — compact entry in the tab bar -->
+        <button class="blinddate-tab-btn" title="@L["BlindDate_EntryButton"]" aria-label="@L["BlindDate_EntryButton"]"
+                @onclick='() => Navigation.NavigateTo("/blind-date")'>🎁</button>
     </div>
 
     @if (activeTab == "shelves")

--- a/BookLoggerApp/Components/Pages/Bookshelf.razor
+++ b/BookLoggerApp/Components/Pages/Bookshelf.razor
@@ -48,6 +48,13 @@
         </button>
     </div>
 
+    <!-- Blind Date with a Book (Sub-TBR Roulette) entry -->
+    <div class="blinddate-entry">
+        <button class="blinddate-entry-btn" @onclick='() => Navigation.NavigateTo("/blind-date")'>
+            🎁 @L["BlindDate_EntryButton"]
+        </button>
+    </div>
+
     @if (activeTab == "shelves")
     {
     <!-- Header & Controls -->

--- a/BookLoggerApp/Components/Shared/BlindDateCard.razor
+++ b/BookLoggerApp/Components/Shared/BlindDateCard.razor
@@ -1,0 +1,31 @@
+@using BookLoggerApp.Core.Resources
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<AppResources> L
+
+<div class="blinddate-card" @onclick="HandlePick">
+    <div class="blinddate-card-wrap">
+        <div class="blinddate-card-ribbon-v"></div>
+        <div class="blinddate-card-ribbon-h"></div>
+        <div class="blinddate-card-bow">🎀</div>
+    </div>
+    <div class="blinddate-card-body">
+        <div class="blinddate-vibes @(IsGenreFallback ? "genre-fallback" : "")">
+            @foreach (var vibe in Vibes)
+            {
+                <span class="blinddate-vibe">@vibe</span>
+            }
+        </div>
+        <span class="blinddate-card-hint">@L["BlindDate_CardHint"]</span>
+    </div>
+</div>
+
+@code {
+    [Parameter] public IReadOnlyList<string> Vibes { get; set; } = new List<string>();
+    [Parameter] public bool IsGenreFallback { get; set; }
+    [Parameter] public EventCallback OnPick { get; set; }
+
+    private async Task HandlePick()
+    {
+        await OnPick.InvokeAsync();
+    }
+}

--- a/BookLoggerApp/MauiProgram.cs
+++ b/BookLoggerApp/MauiProgram.cs
@@ -229,6 +229,7 @@ public static class MauiProgram
         builder.Services.AddTransient<BookLoggerApp.Core.Services.Abstractions.IShelfService, BookLoggerApp.Infrastructure.Services.ShelfService>();
         builder.Services.AddTransient<BookLoggerApp.Core.Services.Abstractions.IDecorationService, BookLoggerApp.Infrastructure.Services.DecorationService>();
         builder.Services.AddTransient<BookLoggerApp.Core.Services.Abstractions.IWishlistService, BookLoggerApp.Infrastructure.Services.WishlistService>();
+        builder.Services.AddTransient<BookLoggerApp.Core.Services.Abstractions.IBlindDateService, BookLoggerApp.Infrastructure.Services.BlindDateService>();
 
         // Database initializer service — used by the UI to retry a failed DB init
         builder.Services.AddSingleton<BookLoggerApp.Core.Services.Abstractions.IDatabaseInitializer, BookLoggerApp.Infrastructure.Services.DatabaseInitializer>();
@@ -286,6 +287,7 @@ public static class MauiProgram
         builder.Services.AddTransient<DecorationShopViewModel>();
         builder.Services.AddTransient<UserProgressViewModel>();
         builder.Services.AddTransient<WishlistViewModel>();
+        builder.Services.AddTransient<BlindDateViewModel>();
         builder.Services.AddTransient<PaywallViewModel>();
         builder.Services.AddSingleton<AppStartupViewModel>();
     }

--- a/BookLoggerApp/wwwroot/css/blinddate.css
+++ b/BookLoggerApp/wwwroot/css/blinddate.css
@@ -231,8 +231,20 @@
     border-radius: var(--border-radius);
 }
 
-.blinddate-no-cover {
-    font-size: 3rem;
+/* No cover image → the book title is written into the cover box. */
+.blinddate-cover-title {
+    display: -webkit-box;
+    -webkit-line-clamp: 7;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    padding: 0.85rem;
+    color: var(--text-primary);
+    font-family: Georgia, "Times New Roman", serif;
+    font-weight: 700;
+    font-size: 1.05rem;
+    line-height: 1.3;
+    text-align: center;
+    overflow-wrap: anywhere;
 }
 
 /* Gift-wrap overlay sitting on top of the cover; animated away on reveal. */

--- a/BookLoggerApp/wwwroot/css/blinddate.css
+++ b/BookLoggerApp/wwwroot/css/blinddate.css
@@ -1,0 +1,334 @@
+/* Blind Date with a Book (Sub-TBR Roulette) */
+
+/* Entry button on the bookshelf page */
+.blinddate-entry {
+    display: flex;
+    justify-content: center;
+    margin: 0.25rem 0 1rem;
+}
+
+.blinddate-entry-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.6rem 1.4rem;
+    border: none;
+    border-radius: 999px;
+    background: var(--gradient-warm);
+    color: var(--bg-primary);
+    font-weight: 700;
+    font-size: 0.95rem;
+    cursor: pointer;
+    box-shadow: var(--shadow);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.blinddate-entry-btn:hover,
+.blinddate-entry-btn:active {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-hover), var(--glow);
+}
+
+.blinddate-container {
+    padding: 1.25rem 1rem 6rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.blinddate-hero {
+    text-align: center;
+    margin-bottom: 1.5rem;
+}
+
+.blinddate-hero h1 {
+    color: var(--text-primary);
+    margin: 0 0 0.4rem;
+}
+
+.blinddate-subtitle {
+    color: var(--text-secondary);
+    max-width: 460px;
+    margin: 0 auto;
+}
+
+.blinddate-prompt {
+    text-align: center;
+    color: var(--text-primary);
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+/* ---- Wrapped card grid ---- */
+
+.blinddate-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 1rem;
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.blinddate-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    min-height: 240px;
+    border-radius: var(--border-radius-lg);
+    overflow: hidden;
+    cursor: pointer;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    box-shadow: var(--shadow);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    animation: blindPop 0.4s ease both;
+    will-change: transform;
+}
+
+.blinddate-card:nth-child(2) {
+    animation-delay: 0.08s;
+}
+
+.blinddate-card:nth-child(3) {
+    animation-delay: 0.16s;
+}
+
+.blinddate-card:hover,
+.blinddate-card:active {
+    transform: translateY(-6px) scale(1.02);
+    box-shadow: var(--shadow-hover), var(--glow);
+}
+
+.blinddate-card-wrap {
+    position: relative;
+    height: 120px;
+    background-image:
+        repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.08) 0 12px, transparent 12px 24px),
+        var(--gradient-warm);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.blinddate-card-ribbon-v {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 18px;
+    transform: translateX(-50%);
+    background: rgba(26, 20, 16, 0.55);
+}
+
+.blinddate-card-ribbon-h {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    height: 18px;
+    transform: translateY(-50%);
+    background: rgba(26, 20, 16, 0.55);
+}
+
+.blinddate-card-bow {
+    position: relative;
+    z-index: 1;
+    font-size: 2.4rem;
+    filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.4));
+}
+
+.blinddate-card-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 1rem;
+    text-align: center;
+}
+
+.blinddate-vibes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    justify-content: center;
+}
+
+.blinddate-vibe {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    padding: 0.3rem 0.7rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.blinddate-vibes.genre-fallback .blinddate-vibe {
+    color: var(--text-secondary);
+    font-style: italic;
+}
+
+.blinddate-card-hint {
+    color: var(--text-muted);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.blinddate-shuffle {
+    text-align: center;
+    margin-top: 1.5rem;
+}
+
+/* ---- Reveal ---- */
+
+.blinddate-reveal {
+    display: flex;
+    justify-content: center;
+    animation: blindFadeIn 0.3s ease;
+}
+
+.blinddate-reveal-card {
+    position: relative;
+    overflow: visible;
+    width: 100%;
+    max-width: 360px;
+    padding: 2rem 1.5rem;
+    text-align: center;
+    background: var(--gradient-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-lg);
+    box-shadow: var(--shadow-hover), var(--glow);
+    animation: blindUnwrap 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55) both;
+}
+
+.blinddate-reveal-header {
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.8rem;
+    margin-bottom: 1rem;
+}
+
+.blinddate-reveal-cover {
+    width: 150px;
+    height: 225px;
+    margin: 0 auto 1rem;
+    border-radius: var(--border-radius);
+    overflow: hidden;
+    background: var(--bg-tertiary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: var(--shadow);
+    animation: blindCoverIn 0.7s ease 0.25s both;
+}
+
+.blinddate-reveal-cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.blinddate-no-cover {
+    font-size: 3rem;
+}
+
+.blinddate-reveal-title {
+    color: var(--text-primary);
+    margin: 0 0 0.25rem;
+}
+
+.blinddate-reveal-author {
+    color: var(--text-secondary);
+    margin: 0 0 1.5rem;
+}
+
+.blinddate-reveal-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+/* ---- Empty / loading / error ---- */
+
+.blinddate-empty {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--text-secondary);
+}
+
+.blinddate-empty-icon {
+    font-size: 3rem;
+    margin-bottom: 0.75rem;
+}
+
+.blinddate-empty h2 {
+    color: var(--text-primary);
+    margin-bottom: 0.5rem;
+}
+
+.blinddate-empty p {
+    max-width: 360px;
+    margin: 0 auto 1.25rem;
+}
+
+.blinddate-container .loading-state,
+.blinddate-container .error-state {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--text-secondary);
+}
+
+/* ---- Animations ---- */
+
+@keyframes blindPop {
+    from {
+        opacity: 0;
+        transform: translateY(12px) scale(0.96);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+@keyframes blindFadeIn {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes blindUnwrap {
+    0% {
+        opacity: 0;
+        transform: scale(0.6) rotate(-4deg);
+    }
+
+    60% {
+        transform: scale(1.04) rotate(1deg);
+    }
+
+    100% {
+        opacity: 1;
+        transform: scale(1) rotate(0);
+    }
+}
+
+@keyframes blindCoverIn {
+    0% {
+        opacity: 0;
+        transform: rotateY(90deg);
+    }
+
+    100% {
+        opacity: 1;
+        transform: rotateY(0);
+    }
+}

--- a/BookLoggerApp/wwwroot/css/blinddate.css
+++ b/BookLoggerApp/wwwroot/css/blinddate.css
@@ -1,32 +1,22 @@
 /* Blind Date with a Book (Sub-TBR Roulette) */
 
-/* Entry button on the bookshelf page */
-.blinddate-entry {
-    display: flex;
-    justify-content: center;
-    margin: 0.25rem 0 1rem;
-}
-
-.blinddate-entry-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.6rem 1.4rem;
+/* Compact entry button that lives at the right end of the bookshelf tab bar */
+.blinddate-tab-btn {
+    flex: 0 0 auto;
+    padding: 0.5rem 0.85rem;
+    background: transparent;
     border: none;
-    border-radius: 999px;
-    background: var(--gradient-warm);
-    color: var(--bg-primary);
-    font-weight: 700;
-    font-size: 0.95rem;
+    border-bottom: 3px solid transparent;
+    font-size: 1.25rem;
+    line-height: 1;
     cursor: pointer;
-    box-shadow: var(--shadow);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    transition: var(--transition);
 }
 
-.blinddate-entry-btn:hover,
-.blinddate-entry-btn:active {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-hover), var(--glow);
+.blinddate-tab-btn:hover,
+.blinddate-tab-btn:active {
+    transform: scale(1.12);
+    background: rgba(212, 165, 116, 0.05);
 }
 
 .blinddate-container {
@@ -80,16 +70,31 @@
     border: 1px solid var(--border-color);
     box-shadow: var(--shadow);
     transition: transform 0.25s ease, box-shadow 0.25s ease;
-    animation: blindPop 0.4s ease both;
+    animation: blindDeal 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) both;
     will-change: transform;
 }
 
 .blinddate-card:nth-child(2) {
-    animation-delay: 0.08s;
+    animation-delay: 0.1s;
 }
 
 .blinddate-card:nth-child(3) {
-    animation-delay: 0.16s;
+    animation-delay: 0.2s;
+}
+
+/* Shuffle: gather the current cards out before the fresh set is dealt in. */
+.blinddate-card-grid.shuffling .blinddate-card {
+    animation: shuffleOut 0.4s ease both;
+    animation-delay: 0s;
+    pointer-events: none;
+}
+
+.blinddate-card-grid.shuffling .blinddate-card:nth-child(2) {
+    animation-delay: 0.07s;
+}
+
+.blinddate-card-grid.shuffling .blinddate-card:nth-child(3) {
+    animation-delay: 0.14s;
 }
 
 .blinddate-card:hover,
@@ -316,42 +321,67 @@
     gap: 0.6rem;
 }
 
-/* Book text + buttons fade in after the wrapping is gone (both variants). */
+/* Book text + buttons fade in only after the (longer) unwrap finishes. */
 .blinddate-reveal-title,
 .blinddate-reveal-author,
 .blinddate-reveal-actions {
-    animation: blindContentIn 0.4s ease 0.55s both;
+    animation: blindContentIn 0.5s ease 1.7s both;
 }
 
-/* === Variant 1: Geschenk auspacken (paper peels open, bow pops) === */
+/* Burst of light at the moment the cover is revealed. */
+.blinddate-reveal-cover::after {
+    content: "";
+    position: absolute;
+    inset: -35%;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(255, 238, 205, 0.85), rgba(255, 238, 205, 0) 70%);
+    opacity: 0;
+    pointer-events: none;
+    z-index: 3;
+}
+
+.reveal-unwrap .blinddate-reveal-cover::after {
+    animation: revealFlash 0.8s ease 1.25s both;
+}
+
+.reveal-burst .blinddate-reveal-cover::after {
+    animation: revealFlash 0.8s ease 1.05s both;
+}
+
+/* === Variant 1: Geschenk auspacken — anticipation, then slow 3D peel (~2.2s) === */
 .reveal-unwrap .blinddate-reveal-card {
-    animation: blindCardIn 0.4s ease both;
+    animation: blindCardIn 0.5s ease both;
+}
+
+/* 0–0.6s: the wrapped cover "breathes" to build anticipation before opening. */
+.reveal-unwrap .blinddate-wrap-overlay {
+    animation: wrapBreathe 0.6s ease both;
 }
 
 .reveal-unwrap .wrap-left {
-    animation: wrapOpenLeft 0.6s ease 0.15s both;
+    animation: wrapOpenLeft 1s cubic-bezier(0.5, 0, 0.3, 1) 0.6s both;
 }
 
 .reveal-unwrap .wrap-right {
-    animation: wrapOpenRight 0.6s ease 0.15s both;
+    animation: wrapOpenRight 1s cubic-bezier(0.5, 0, 0.3, 1) 0.6s both;
 }
 
 .reveal-unwrap .wrap-ribbon {
-    animation: blindFadeOut 0.3s ease 0.15s both;
+    animation: blindFadeOut 0.4s ease 0.65s both;
 }
 
 .reveal-unwrap .wrap-bow {
-    animation: bowPop 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55) 0.1s both;
+    animation: bowPop 1s cubic-bezier(0.34, 1.56, 0.64, 1) 0.5s both;
 }
 
-/* === Variant 2: Shake & Burst (card shakes, wrapping bursts away) === */
+/* === Variant 2: Shake & Burst — long crescendo shake, then explosion (~1.6s) === */
 .reveal-burst .blinddate-reveal-card {
-    animation: blindShakeBurst 0.8s ease both;
+    animation: blindShakeBurst 1.6s ease both;
 }
 
 /* The whole wrapping (halves, ribbon, bow as children) bursts outward together. */
 .reveal-burst .blinddate-wrap-overlay {
-    animation: blindBurstAway 0.32s ease 0.4s both;
+    animation: blindBurstAway 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) 1.05s both;
 }
 
 /* ---- Empty / loading / error ---- */
@@ -386,15 +416,34 @@
 
 /* ---- Animations ---- */
 
-@keyframes blindPop {
-    from {
+/* Cards are "dealt" in (used on load and after a shuffle). */
+@keyframes blindDeal {
+    0% {
         opacity: 0;
-        transform: translateY(12px) scale(0.96);
+        transform: translateY(-36px) rotate(-10deg) scale(0.8);
     }
 
-    to {
+    60% {
         opacity: 1;
-        transform: translateY(0) scale(1);
+        transform: translateY(0) rotate(3deg) scale(1.04);
+    }
+
+    100% {
+        opacity: 1;
+        transform: rotate(0) scale(1);
+    }
+}
+
+/* Cards spin/gather away when the shuffle button is pressed. */
+@keyframes shuffleOut {
+    0% {
+        opacity: 1;
+        transform: translateY(0) rotate(0) scale(1);
+    }
+
+    100% {
+        opacity: 0;
+        transform: translateY(-26px) rotate(16deg) scale(0.55);
     }
 }
 
@@ -442,71 +491,71 @@
     }
 }
 
-/* Variant 1 — paper flaps swing open in 3D */
-@keyframes wrapOpenLeft {
-    0% {
-        opacity: 1;
-        transform: rotateY(0deg);
-    }
+/* Variant 1 — gentle "breathe" to build anticipation before opening */
+@keyframes wrapBreathe {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+}
 
-    100% {
-        opacity: 0;
-        transform: rotateY(-118deg) translateX(-8%);
-    }
+/* Variant 1 — paper flaps swing wide open in 3D */
+@keyframes wrapOpenLeft {
+    0% { opacity: 1; transform: rotateY(0deg); }
+    70% { opacity: 1; }
+    100% { opacity: 0; transform: rotateY(-135deg) translateX(-10%); }
 }
 
 @keyframes wrapOpenRight {
-    0% {
-        opacity: 1;
-        transform: rotateY(0deg);
-    }
-
-    100% {
-        opacity: 0;
-        transform: rotateY(118deg) translateX(8%);
-    }
+    0% { opacity: 1; transform: rotateY(0deg); }
+    70% { opacity: 1; }
+    100% { opacity: 0; transform: rotateY(135deg) translateX(10%); }
 }
 
-/* Variant 1 — the bow pops up and away */
+/* Variant 1 — the bow wobbles with suspense, then flies up, spins and shrinks away */
 @keyframes bowPop {
-    0% {
-        opacity: 1;
-        transform: translate(-50%, -50%) scale(1);
-    }
-
-    35% {
-        opacity: 1;
-        transform: translate(-50%, -70%) scale(1.35);
-    }
-
-    100% {
-        opacity: 0;
-        transform: translate(-50%, -260%) scale(0.5);
-    }
+    0% { opacity: 1; transform: translate(-50%, -50%) rotate(0) scale(1); }
+    10% { transform: translate(-50%, -50%) rotate(-9deg) scale(1.06); }
+    20% { transform: translate(-50%, -50%) rotate(9deg) scale(1.06); }
+    30% { transform: translate(-50%, -50%) rotate(-7deg) scale(1.1); }
+    40% { transform: translate(-50%, -54%) rotate(0deg) scale(1.18); }
+    60% { opacity: 1; transform: translate(-50%, -110%) rotate(180deg) scale(1); }
+    100% { opacity: 0; transform: translate(-50%, -340%) rotate(430deg) scale(0.25); }
 }
 
-/* Variant 2 — tension shake, then a confident pop */
+/* Variant 2 — a long crescendo shake (subtle → violent), a beat, then a punch */
 @keyframes blindShakeBurst {
     0% { transform: translateX(0) scale(1); }
-    8% { transform: translateX(-7px) scale(1); }
-    16% { transform: translateX(7px) scale(1); }
-    24% { transform: translateX(-6px) scale(1); }
-    32% { transform: translateX(6px) scale(1); }
-    40% { transform: translateX(-3px) scale(1); }
-    48% { transform: translateX(0) scale(1); }
-    70% { transform: translateX(0) scale(1.07); }
+    6% { transform: translateX(-2px); }
+    12% { transform: translateX(2px); }
+    18% { transform: translateX(-3px); }
+    24% { transform: translateX(3px); }
+    30% { transform: translateX(-5px); }
+    36% { transform: translateX(5px); }
+    42% { transform: translateX(-7px); }
+    48% { transform: translateX(7px); }
+    54% { transform: translateX(-9px) scale(1.02); }
+    60% { transform: translateX(9px) scale(1.02); }
+    63% { transform: translateX(0) scale(1.03); }
+    67% { transform: translateX(0) scale(0.96); }
+    76% { transform: translateX(0) scale(1.13); }
     100% { transform: translateX(0) scale(1); }
 }
 
-/* Variant 2 — the wrapping bursts outward */
+/* Variant 2 — the wrapping explodes outward */
 @keyframes blindBurstAway {
     0% {
         opacity: 1;
-        transform: scale(1);
+        transform: scale(1) rotate(0deg);
     }
 
     100% {
         opacity: 0;
-        transform: scale(1.7);
+        transform: scale(2.3) rotate(12deg);
     }
+}
+
+/* Burst of light when the cover is revealed (both variants) */
+@keyframes revealFlash {
+    0% { opacity: 0; transform: scale(0.4); }
+    25% { opacity: 0.9; transform: scale(1); }
+    100% { opacity: 0; transform: scale(1.6); }
 }

--- a/BookLoggerApp/wwwroot/css/blinddate.css
+++ b/BookLoggerApp/wwwroot/css/blinddate.css
@@ -200,7 +200,6 @@
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius-lg);
     box-shadow: var(--shadow-hover), var(--glow);
-    animation: blindUnwrap 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55) both;
 }
 
 .blinddate-reveal-header {
@@ -212,27 +211,81 @@
 }
 
 .blinddate-reveal-cover {
+    position: relative;
     width: 150px;
     height: 225px;
     margin: 0 auto 1rem;
     border-radius: var(--border-radius);
-    overflow: hidden;
     background: var(--bg-tertiary);
     display: flex;
     align-items: center;
     justify-content: center;
     box-shadow: var(--shadow);
-    animation: blindCoverIn 0.7s ease 0.25s both;
+    perspective: 900px;
 }
 
 .blinddate-reveal-cover img {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    border-radius: var(--border-radius);
 }
 
 .blinddate-no-cover {
     font-size: 3rem;
+}
+
+/* Gift-wrap overlay sitting on top of the cover; animated away on reveal. */
+.blinddate-wrap-overlay {
+    position: absolute;
+    inset: 0;
+    border-radius: var(--border-radius);
+    transform-style: preserve-3d;
+    perspective: 700px;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.blinddate-wrap-overlay .wrap-half {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 50%;
+    background-image:
+        repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.08) 0 12px, transparent 12px 24px),
+        var(--gradient-warm);
+    backface-visibility: hidden;
+}
+
+.blinddate-wrap-overlay .wrap-left {
+    left: 0;
+    transform-origin: left center;
+    border-radius: var(--border-radius) 0 0 var(--border-radius);
+}
+
+.blinddate-wrap-overlay .wrap-right {
+    right: 0;
+    transform-origin: right center;
+    border-radius: 0 var(--border-radius) var(--border-radius) 0;
+}
+
+.blinddate-wrap-overlay .wrap-ribbon {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 16px;
+    transform: translateX(-50%);
+    background: rgba(26, 20, 16, 0.55);
+}
+
+.blinddate-wrap-overlay .wrap-bow {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    font-size: 2.6rem;
+    transform: translate(-50%, -50%);
+    filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.4));
 }
 
 .blinddate-reveal-title {
@@ -249,6 +302,44 @@
     display: flex;
     flex-direction: column;
     gap: 0.6rem;
+}
+
+/* Book text + buttons fade in after the wrapping is gone (both variants). */
+.blinddate-reveal-title,
+.blinddate-reveal-author,
+.blinddate-reveal-actions {
+    animation: blindContentIn 0.4s ease 0.55s both;
+}
+
+/* === Variant 1: Geschenk auspacken (paper peels open, bow pops) === */
+.reveal-unwrap .blinddate-reveal-card {
+    animation: blindCardIn 0.4s ease both;
+}
+
+.reveal-unwrap .wrap-left {
+    animation: wrapOpenLeft 0.6s ease 0.15s both;
+}
+
+.reveal-unwrap .wrap-right {
+    animation: wrapOpenRight 0.6s ease 0.15s both;
+}
+
+.reveal-unwrap .wrap-ribbon {
+    animation: blindFadeOut 0.3s ease 0.15s both;
+}
+
+.reveal-unwrap .wrap-bow {
+    animation: bowPop 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55) 0.1s both;
+}
+
+/* === Variant 2: Shake & Burst (card shakes, wrapping bursts away) === */
+.reveal-burst .blinddate-reveal-card {
+    animation: blindShakeBurst 0.8s ease both;
+}
+
+/* The whole wrapping (halves, ribbon, bow as children) bursts outward together. */
+.reveal-burst .blinddate-wrap-overlay {
+    animation: blindBurstAway 0.32s ease 0.4s both;
 }
 
 /* ---- Empty / loading / error ---- */
@@ -305,30 +396,105 @@
     }
 }
 
-@keyframes blindUnwrap {
-    0% {
+@keyframes blindCardIn {
+    from {
         opacity: 0;
-        transform: scale(0.6) rotate(-4deg);
+        transform: scale(0.96);
     }
 
-    60% {
-        transform: scale(1.04) rotate(1deg);
-    }
-
-    100% {
+    to {
         opacity: 1;
-        transform: scale(1) rotate(0);
+        transform: scale(1);
     }
 }
 
-@keyframes blindCoverIn {
-    0% {
+@keyframes blindContentIn {
+    from {
         opacity: 0;
-        transform: rotateY(90deg);
+        transform: translateY(8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes blindFadeOut {
+    from {
+        opacity: 1;
+    }
+
+    to {
+        opacity: 0;
+    }
+}
+
+/* Variant 1 — paper flaps swing open in 3D */
+@keyframes wrapOpenLeft {
+    0% {
+        opacity: 1;
+        transform: rotateY(0deg);
     }
 
     100% {
+        opacity: 0;
+        transform: rotateY(-118deg) translateX(-8%);
+    }
+}
+
+@keyframes wrapOpenRight {
+    0% {
         opacity: 1;
-        transform: rotateY(0);
+        transform: rotateY(0deg);
+    }
+
+    100% {
+        opacity: 0;
+        transform: rotateY(118deg) translateX(8%);
+    }
+}
+
+/* Variant 1 — the bow pops up and away */
+@keyframes bowPop {
+    0% {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1);
+    }
+
+    35% {
+        opacity: 1;
+        transform: translate(-50%, -70%) scale(1.35);
+    }
+
+    100% {
+        opacity: 0;
+        transform: translate(-50%, -260%) scale(0.5);
+    }
+}
+
+/* Variant 2 — tension shake, then a confident pop */
+@keyframes blindShakeBurst {
+    0% { transform: translateX(0) scale(1); }
+    8% { transform: translateX(-7px) scale(1); }
+    16% { transform: translateX(7px) scale(1); }
+    24% { transform: translateX(-6px) scale(1); }
+    32% { transform: translateX(6px) scale(1); }
+    40% { transform: translateX(-3px) scale(1); }
+    48% { transform: translateX(0) scale(1); }
+    70% { transform: translateX(0) scale(1.07); }
+    100% { transform: translateX(0) scale(1); }
+}
+
+/* Variant 2 — the wrapping bursts outward */
+@keyframes blindBurstAway {
+    0% {
+        opacity: 1;
+        transform: scale(1);
+    }
+
+    100% {
+        opacity: 0;
+        transform: scale(1.7);
     }
 }

--- a/BookLoggerApp/wwwroot/index.html
+++ b/BookLoggerApp/wwwroot/index.html
@@ -28,6 +28,7 @@
 
     <link rel="stylesheet" href="css/plantshop.css" />
     <link rel="stylesheet" href="css/wishlist.css" />
+    <link rel="stylesheet" href="css/blinddate.css" />
     <link rel="stylesheet" href="css/privacy.css" />
     <link rel="stylesheet" href="css/paywall.css" />
     <link rel="stylesheet" href="BookLoggerApp.styles.css" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versionsschema:
 - `V1.0.0` – Erster öffentlicher Play-Store-Release
 - MAJOR wird auf 1 gesetzt wenn der erste public Play-Store-Upload erfolgt
 - MINOR für neue Features, PATCH für Bugfixes und kleinere Änderungen
+
+## [Unveröffentlicht]
+
+### Hinzugefügt
+- „Blind Date mit einem Buch" (Sub-TBR Roulette): Ein neuer Button auf dem Bücherregal öffnet eine Roulette-Ansicht, die Cover und Titel ungelesener Bücher (TBR + Wishlist) verbirgt und stattdessen nur 3–4 Vibes (Tropes, ersatzweise das Genre) auf „verpackten" Karten zeigt. Man wählt nach den Vibes und packt das Buch per Animation aus. Alle UI-Texte sind in Deutsch und Englisch lokalisiert.
+
 ## [0.11.5]
 
 ### Behoben


### PR DESCRIPTION
## Summary

Implements the "Blind Date with a Book" feature — a gamified book discovery experience where users pick from wrapped cards showing only book vibes (tropes or genres), then unwrap to reveal the full book details. This is a Sub-TBR Roulette variant that draws from unread books (Planned + Wishlist status).

## Key Changes

- **Service Layer**
  - Added `IBlindDateService` interface and `BlindDateService` implementation to fetch unread book candidates with eager-loaded tropes and genres
  - Uses `DbContextFactory` pattern for thread-safe read operations (consistent with `WishlistService`)

- **ViewModel**
  - Added `BlindDateViewModel` with MVVM Toolkit observables and relay commands
  - Implements card drawing (3 random books per round), vibe extraction (tropes → genres fallback → mystery), and reveal logic
  - Randomly selects between two reveal animations (Unwrap or Burst) for variety
  - Caps displayed vibes at 4 per card

- **UI Components**
  - New page `BlindDate.razor` with three states: card selection, reveal, and empty/error handling
  - New shared component `BlindDateCard.razor` for wrapped card display
  - Entry button added to `Bookshelf.razor` to navigate to the feature

- **Styling**
  - Comprehensive CSS (`blinddate.css`) with:
    - Gift-wrapped card grid with staggered pop-in animations
    - Two reveal animation variants: paper unwrap (3D rotation) and burst (shake + scale)
    - Confetti effect and smooth transitions
    - Responsive design with proper fallbacks for missing cover images

- **Localization**
  - Added 13 new resource keys (EN + DE) covering all UI text and empty states

- **Testing**
  - Unit tests for `BlindDateViewModel` covering candidate loading, vibe extraction, animation selection, and state transitions
  - Integration tests for `BlindDateService` verifying correct filtering (Planned/Wishlist only) and eager loading of relations

- **DI & Configuration**
  - Registered `IBlindDateService` and `BlindDateViewModel` in `MauiProgram.cs`
  - Added stylesheet link to `index.html`
  - Updated `CHANGELOG.md` with feature entry

## Implementation Details

- **Vibe Selection**: Books with tropes show trope names; fallback to genre names if no tropes exist; final fallback to localized "mystery" string if neither exist
- **Card Limit**: Always shows 3 cards per round; shuffle draws a fresh random set
- **Cover Handling**: Displays book cover image if available; falls back to title text centered in the cover box
- **Animation Randomization**: Each reveal picks Unwrap or Burst at random (50/50) to keep the experience varied
- **Accessibility**: Proper button semantics, loading/error states, and navigation feedback

https://claude.ai/code/session_01QcbtD4fYUptgyGdDhYX5dM