### PR TITLE
Fix "Suggest a feature" email composer error on Android 11+

### DIFF
--- a/BookLoggerApp/Components/Shared/FeatureSuggestionForm.razor
+++ b/BookLoggerApp/Components/Shared/FeatureSuggestionForm.razor
@@ -47,7 +47,16 @@
             string uri = BuildMailtoUri(RecipientEmail, subject, body);
 
 #if ANDROID
-            await Microsoft.Maui.ApplicationModel.Launcher.OpenAsync(new Uri(uri));
+            if (Microsoft.Maui.ApplicationModel.Communication.Email.Default.IsComposeSupported)
+            {
+                Microsoft.Maui.ApplicationModel.Communication.EmailMessage message =
+                    new(subject, body, RecipientEmail);
+                await Microsoft.Maui.ApplicationModel.Communication.Email.Default.ComposeAsync(message);
+            }
+            else
+            {
+                await Microsoft.Maui.ApplicationModel.Launcher.OpenAsync(new Uri(uri));
+            }
 #else
             Navigation.NavigateTo(uri);
             await Task.CompletedTask;

--- a/BookLoggerApp/Platforms/Android/AndroidManifest.xml
+++ b/BookLoggerApp/Platforms/Android/AndroidManifest.xml
@@ -18,6 +18,19 @@
                 android:value="live_reading_session_timer" />
         </service>
     </application>
+    <!-- Android 11+ package visibility: declare email intents so Email.ComposeAsync /
+         Launcher.OpenAsync(mailto:) can resolve an installed email client (used by the
+         "Suggest a feature" Premium form). Without this, the launch fails silently. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SENDTO" />
+            <data android:scheme="mailto" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="mailto" />
+        </intent>
+    </queries>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CAMERA" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Versionsschema:
 - „Blind Date mit einem Buch" (Sub-TBR Roulette): Ein neuer Button auf dem Bücherregal öffnet eine Roulette-Ansicht, die Cover und Titel ungelesener Bücher (TBR + Wishlist) verbirgt und stattdessen nur 3–4 Vibes (Tropes, ersatzweise das Genre) auf „verpackten" Karten zeigt. Man wählt nach den Vibes und packt das Buch per Animation aus. Alle UI-Texte sind in Deutsch und Englisch lokalisiert.
 - Live-Lese-Timer als dauerhafte Benachrichtigung (Android-Vordergrunddienst): Während einer aktiven Lesesitzung erscheint auf dem Sperrbildschirm und in der Statusleiste eine Benachrichtigung mit Buchtitel und mitlaufender Zeit. Über die Schaltflächen lässt sich der Timer pausieren/fortsetzen oder stoppen; „Stopp" pausiert und öffnet die Buchdetailseite (mit dem dort pausierten Lese-Timer), damit die Seite bestätigt und normal gespeichert werden kann. Ein Tippen auf die Benachrichtigung öffnet ebenfalls die Buchdetailseite. Die Benachrichtigungstexte folgen der in der App gewählten Sprache (Deutsch/Englisch). Lässt sich in den Einstellungen unter „Benachrichtigungen → Live-Lese-Timer" abschalten.
 
+### Behoben
+- Feature-Vorschlag per E-Mail (Premium): „E-Mail-Programm konnte nicht geöffnet werden" auf Android 11+ behoben — fehlende `<queries>`-Deklaration für `mailto`-Intents im Android-Manifest ergänzt und auf die native `Email.ComposeAsync`-API umgestellt.
+
 ## [0.11.5]
 
 ### Behoben


### PR DESCRIPTION
The Premium feature-suggestion form failed with "Could not open the email
composer." because the Android manifest lacked a <queries> declaration.
Android 11+ scopes package visibility, so without declaring the mailto
intents the app cannot resolve any email client and the launch throws.

- Add <queries> block for SENDTO/VIEW mailto intents to AndroidManifest.xml
- Switch the Android path to Email.ComposeAsync with a mailto Launcher
  fallback for reliable subject/body handling
- Add changelog entry under Behoben

https://claude.ai/code/session_01McKNMstd6btukjNkobjkgo